### PR TITLE
Fix console resizing

### DIFF
--- a/retype/console/console.py
+++ b/retype/console/console.py
@@ -1,4 +1,4 @@
-from qt import pyqtSignal, Qt, QSize
+from qt import pyqtSignal, Qt, QSizePolicy
 
 from retype.ui import LineEdit
 from retype.console import CommandService, HighlightingService
@@ -11,6 +11,7 @@ class Console(LineEdit):
         super().__init__(parent)
         self.setAccessibleName("console")
         self.returnPressed.connect(self._handleReturnPressed)
+        self.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Preferred)
         self.setMaximumHeight(200)
 
         self._prompt = prompt
@@ -52,12 +53,9 @@ class Console(LineEdit):
             self.setFocus()
             self.keyPressEvent(e)
 
-    def sizeHint(self):  # TODO
-        return QSize(15, 15)
-
     def resizeEvent(self, e):
         height = self.size().height()
-        if height:
+        if height > 10:
             px = int(0.8 * height - 5)
             self.setStyleSheet("font-size: {}px".format(px))
         super().resizeEvent(e)

--- a/retype/console/console.py
+++ b/retype/console/console.py
@@ -14,6 +14,7 @@ class Console(LineEdit):
         self.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Preferred)
         self.setMaximumHeight(200)
 
+        self._font = self.font()
         self._prompt = prompt
 
     @property
@@ -57,5 +58,6 @@ class Console(LineEdit):
         height = self.size().height()
         if height > 10:
             px = int(0.8 * height - 5)
-            self.setStyleSheet("font-size: {}px".format(px))
+            self._font.setPixelSize(px)
+            self.setFont(self._font)
         super().resizeEvent(e)

--- a/retype/ui/line_edit.py
+++ b/retype/ui/line_edit.py
@@ -80,6 +80,12 @@ class LineEdit(QWidget):
     def sizeHint(self):
         return self.edit.sizeHint()
 
+    def font(self):
+        return self.edit.font()
+
+    def setFont(self, *args):
+        self.edit.setFont(*args)
+
 
 class _LineEdit(QPlainTextEdit):
     returnPressed = pyqtSignal()


### PR DESCRIPTION
Fixes #9

Also fixes right-click context menu size changing size undesirably which was caused by doing setStyleSheet instead of setFont