### PR TITLE
Identify book by checksum instead of path

### DIFF
--- a/retype/controllers/library.py
+++ b/retype/controllers/library.py
@@ -70,16 +70,15 @@ class LibraryController(object):
 
     def save(self, book, data):
         key = book.checksum
-        if os.path.exists(self.save_abs_path):
-            with open(self.save_abs_path, 'r') as f:
-                save = json.load(f)
-                save[key] = data
+        save = self.save_file_contents
+        if (save):
+            save[key] = data
         else:
-            save = {key: data}
+            save = self.save_file_contents = {key: data}
+
         with open(self.save_abs_path, 'w', encoding='utf-8') as f:
             json.dump(save, f, indent=2)
 
-        self.save_file_contents = save
         book.save_data = data
 
     def migrateV1Save(self, save):

--- a/retype/controllers/library.py
+++ b/retype/controllers/library.py
@@ -69,6 +69,7 @@ class LibraryController(object):
         book_view.display.centreAroundCursor()
 
     def save(self, book, data):
+        self.addFriendlyName(data, book.path)
         key = book.checksum
         save = self.save_file_contents
         if (save):
@@ -100,6 +101,7 @@ class LibraryController(object):
                     checksum = key
                 else:
                     checksum = generate_file_md5(key)
+                    self.addFriendlyName(save[key], key)
             else:  # assume it’s a checksum
                 checksum = key
             if checksum in book_checksum_list:
@@ -109,6 +111,9 @@ class LibraryController(object):
                 book_checksum_list.append(checksum)
             new_save[checksum] = save[key]
         return new_save
+
+    def addFriendlyName(self, data, path):
+        data['friendly_name'] = os.path.basename(path)
 
     def loadSaveFile(self):
         if os.path.exists(self.save_abs_path):

--- a/retype/extras/hashing.py
+++ b/retype/extras/hashing.py
@@ -1,0 +1,14 @@
+import os
+import hashlib
+
+
+def generate_file_md5(path, blocksize=2**20):
+    """https://stackoverflow.com/a/1131255"""
+    m = hashlib.md5()
+    with open(path, "rb") as f:
+        while True:
+            buf = f.read(blocksize)
+            if not buf:
+                break
+            m.update(buf)
+    return m.hexdigest()

--- a/retype/ui/book_view.py
+++ b/retype/ui/book_view.py
@@ -398,12 +398,11 @@ class BookView(QWidget):
 
     def maybeSave(self):
         if self.book:
-            key = self.book.path
             data = {'persistent_pos': self.persistent_pos,
                     'line_pos': self.line_pos,
                     'chapter_pos': self.chapter_pos,
                     'progress': self.progress}
-            self._library.save(self.book, key, data)
+            self._library.save(self.book, data)
 
     def switchToShelves(self):
         self._controller.console.command_service.switch('shelves')

--- a/setup/config/binaries.py
+++ b/setup/config/binaries.py
@@ -7,8 +7,8 @@ if iswindows:
     to_exclude = {
         'Qt5DBus.dll', 'opengl32sw.dll', 'Qt5Network.dll', 'Qt5Qml.dll',
         'Qt5QmlModels.dll', 'Qt5Quick.dll', 'Qt5Svg.dll', 'Qt5WebSockets.dll',
-        '_bz2', '_hashlib', '_socket', '_ssl', 'libcrypto-1_1.dll',
-        'libssl-1_1.dll', 'objectify', 'sax', 'core-libraryloader',
+        '_bz2', '_socket', '_ssl', 'libcrypto-1_1.dll', 'libssl-1_1.dll',
+        'objectify', 'sax', 'core-libraryloader',
     }
 elif islinux:
     to_exclude = {
@@ -22,9 +22,9 @@ elif islinux:
         '_codecs', 'libprotobuf', 'libpango', 'libdbus', 'libgssapi',
         'libmount', 'libQt5WebSockets', 'libfontconfig', 'libblkid',
         'libxkbcommon', 'libmircommon', '_multibytecodec', '_asyncio',
-        'libpng16', '_hashlib', 'libatk', 'libatspi', 'libk5crypto',
+        'libpng16', 'libatk', 'libatspi', 'libk5crypto',
         'libglapi', 'libexpat', 'libgraphite', 'libselinux', 'liblzma', '_sha',
-        'libxcb', '_csv', 'libz', 'libboost', 'libgcc', '_heapq', '_md5',
+        'libxcb', '_csv', 'libz', 'libboost', 'libgcc', '_heapq',
         'libpangoft2', 'mmap', 'libgpg', 'libXext', 'libwayland', '_random',
         'libXi', 'termios', '_multiprocessing', '_bisect', 'libgbm', 'grp',
         'libpangocairo', 'resource', '_queue', 'libXrandr', 'libXrender',
@@ -38,8 +38,8 @@ elif ismacos:
     to_exclude = {
         'libcrypto', 'libncursesw', 'libssl', 'QtNetwork', 'QtQml', 'QtQuick',
         'QtSvg', 'QtWebSockets', 'objectify', 'sax', '_bisect', '_blake2',
-        '_bz2', '_codecs', '_ctypes', '_datetime', '_hashlib', '_heapq',
-        '_json', '_lzma', '_md5', '_multibyte', '_opcode', '_pickle',
+        '_bz2', '_codecs', '_ctypes', '_datetime', '_heapq',
+        '_json', '_lzma', '_multibyte', '_opcode', '_pickle',
         '_random', '_scproxy', '_sha', '_socket', '_ssl', '_uuid', 'grp',
         'pyexpat', 'readline', 'resource', 'termios', 'unicodedata',
     }

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -155,7 +155,7 @@ class TestLibraryControllerLoadFunction:
     def test_load_save_file_v1_two_books_same_checksum(
             self, m_jsonload, m_open, m_exists, m_hash):
         (library, book, data, _) = _setup()
-        save = {book.path: 'different-data', book.checksum: data}
+        save = {book.path: {'different': 'data'}, book.checksum: data}
 
         m_exists.return_value = True
         m_jsonload.return_value = save


### PR DESCRIPTION
Fixes #6 

Includes migration of old format to new format, so users of older versions of retype can still use their old save.