### PR TITLE
feat: Customisation option to require pressing Enter to advance

### DIFF
--- a/retype/console/console.py
+++ b/retype/console/console.py
@@ -37,11 +37,13 @@ class Console(LineEdit):
         self._font.setFamily(value)
         self.setFont(self._font)
 
-    def initServices(self, book_view, switchView, loadBook, customise, about):
+    def initServices(self, book_view, switchView, loadBook, customise, about,
+                     enter_newline):
         self.command_service = CommandService(
             self, book_view, switchView, loadBook, self._prompt, customise,
             about)
-        self.highlighting_service = HighlightingService(self, book_view)
+        self.highlighting_service = HighlightingService(
+            self, book_view, enter_newline)
 
     def _handleReturnPressed(self):
         self.submitted.emit(self.text())

--- a/retype/controllers/main_controller.py
+++ b/retype/controllers/main_controller.py
@@ -150,7 +150,8 @@ class MainController(QObject):
                                   self.switchViewRequested,
                                   self.loadBookRequested,
                                   self.customisationDialogRequested,
-                                  self.aboutDialogRequested)
+                                  self.aboutDialogRequested,
+                                  self.config.get('enter_newline', False))
 
     def saveConfig(self, config):
         self.config.save(config)
@@ -170,6 +171,10 @@ class MainController(QObject):
 
         # Update rdict
         self.views[View.book_view].setRdict(config['rdict'])
+
+        # Update newline_enter
+        self.console.highlighting_service.enter_newline =\
+            config['enter_newline']
 
         # Update library’s user_dir
         self.library.user_dir = config['user_dir']

--- a/retype/extras/space.py
+++ b/retype/extras/space.py
@@ -30,20 +30,26 @@ def isspaceorempty(s, orgarbage=False):
 def spacerstrip(s):
     def _spacerstrip(s):
         return s.rstrip().rstrip(''.join(effectively_space))
-    s = _spacerstrip(s)
-    while s != _spacerstrip(s):
-        s = _spacerstrip(s)
-    return s
+    ns = _spacerstrip(s)
+    while ns != _spacerstrip(ns):
+        ns = _spacerstrip(ns)
+    return ns
 
 
 def nspacerstrip(s):
+    ns = s
     if len(s) and s[-1] == '\n':
-        s = spacerstrip(s[0:-1])
-    return s
+        ns = spacerstrip(s[0:-1])
+    return ns
 
 
 def nrspacerstrip(s):
-    s = nspacerstrip(s)
-    while len(s) and s[-1] == '\r':
-        s = s[0:-1]
-    return s
+    ns = nspacerstrip(s)
+    while len(ns) and ns[-1] == '\r':
+        ns = s[0:-1]
+    return ns
+
+def endsinn(s):
+    if len(s) and s[-1] == '\n':
+        return True
+    return False

--- a/retype/ui/customisation_dialog.py
+++ b/retype/ui/customisation_dialog.py
@@ -168,6 +168,17 @@ class CustomisationDialog(QDialog):
             lambda sdict: self.update("sdict", sdict))
         lyt.addRow(self.selectors['sdict'])
 
+        lyt.addRow(hline())
+        enter_newline_checkbox = CheckBox(
+            "Newline characters advance automatically\n\
+(if off, requires pressing Enter at the end of a line)")
+        enter_newline_checkbox.setChecked(
+            self.config_edited.get('enter_newline', False))
+        enter_newline_checkbox.stateChanged.connect(
+            lambda t: self.update("enter_newline", t))
+        self.selectors['enter_newline'] = enter_newline_checkbox
+        lyt.addRow(enter_newline_checkbox)
+
         return psep
 
     def _rdictSettings(self):


### PR DESCRIPTION
Previously retype automatically advanced to the next line. This patch adds the option 'Newline characters advance automatically' to Customisation Dialog. Checked on is the default and previous behaviour. Checked off makes it so user needs to press Enter to advance past newline.