### PR TITLE
fix(UI): Modeline clipping

### DIFF
--- a/retype/layouts/rowlayout.doctest
+++ b/retype/layouts/rowlayout.doctest
@@ -18,19 +18,23 @@ Import things needed to create a simple test window
 >>> class ExampleWindow(QWidget):
 ...     def __init__(self):
 ...         super().__init__()
-...         self.setLayout(RowLayout(self))
-...
-...         self.layout().setSpacing(10)
-...         self.layout().setContentsMargins(2,2,2,2)
+...         self.setLayout(QVBoxLayout(self))
+...         inner1 = QWidget()
+...         inner2 = QWidget()
+...         inner2.setLayout(RowLayout(inner2))
+...         inner2.layout().setSpacing(0)
+...         inner2.layout().setContentsMargins(0,0,0,0)
+...         self.layout().addWidget(inner1, 1)
+...         self.layout().addWidget(inner2)
+...         inner2.setObjectName('testwidget')
 ...
 ...         for w in range( random.randint(25,50)):
-...           #  words = " ".join(
-...           #      [ "".join([ chr(random.choice(range(ord('a'),ord('z'))))  
-...           #              for x in range( random.randint(2,9) ) ])  
-...           #                  for n in range(random.randint(1,5)) ]).title()
-...             words = "ugh"
+...             words = " ".join(
+...                 [ "".join([ chr(random.choice(range(ord('a'),ord('z'))))  
+...                         for x in range( random.randint(2,9) ) ])  
+...                             for n in range(random.randint(1,5)) ]).title()
 ...             widget = QPushButton(words)
-...             self.layout().addWidget(widget)
+...             inner2.layout().addWidget(widget)
 ...
 
 For now just show the window
@@ -38,7 +42,7 @@ For now just show the window
 >>> app = QApplication(sys.argv)
 >>> mainWin = ExampleWindow()
 >>> mainWin.setGeometry(-900, 300, 800, 600)
->>> app.setStyleSheet("QPushButton {border-style:dashed; border-color: red; border-width: 2px;}")
+>>> app.setStyleSheet("#testwidget {background-color: yellow;} QPushButton {border-style:dashed; border-color: red; border-width: 2px; font-size: 20px;}")
 >>> mainWin.show()
 >>> app.exec_()
 0


### PR DESCRIPTION
* Expand modeline height to fit text
* Draw modeline separators dynamically according to height
* Adjust row layout to support expanding size policy
* Modeline separators and groups adjust to parent height using size policy
* Precise separator width
* Use spacing instead of excess separator width to get the spacing between the separators and text elements

see #2