### PR TITLE
feat(UI): Customisation dialog sidebar

### DIFF
--- a/retype/extras/widgets.py
+++ b/retype/extras/widgets.py
@@ -111,3 +111,22 @@ Adapted from musicamante https://stackoverflow.com/a/70757504/18396947"""
     def hasHeightForWidth(self):
         """Without this, the sizeHint seems to be ignored"""
         return False
+
+
+class MinWidget(QWidget):
+    def __init__(self, min=100, width=True, height=True, parent=None):
+        QWidget.__init__(self, parent)
+        self.min = min
+        self.width = width
+        self.height = height
+
+    def minimumSizeHint(self):
+        size = QWidget.minimumSizeHint(self)
+        if self.width:
+            size.setWidth(self.min)
+        if self.height:
+            size.setHeight(self.min)
+        return size
+
+    def sizeHint(self):
+        return self.minimumSizeHint()

--- a/retype/extras/widgets.py
+++ b/retype/extras/widgets.py
@@ -1,11 +1,16 @@
-from qt import QTabWidget, QStyle, QStyleOptionTabWidgetFrame
+from qt import (QTabWidget, QStyle, QStyleOptionTabWidgetFrame, QStackedWidget,
+                QWidget, QScrollArea, QLabel, QSize, QHBoxLayout,
+                QTextDocument)
 
 
 class AdjustedTabWidget(QTabWidget):
     """QTabWidget descendent whose size adjusts to fit the selected tab.
-By musicamante https://stackoverflow.com/a/72673580/18396947"""
+Adapted from musicamante https://stackoverflow.com/a/72673580/18396947"""
+    def __init__(self, parent=None):
+        QTabWidget.__init__(self, parent)
+
     def minimumSizeHint(self):
-        if self.count() < 0:
+        if self.count() < 0 or not self.currentWidget():
             return super().sizeHint()
 
         baseSize = self.currentWidget().sizeHint().expandedTo(
@@ -20,7 +25,89 @@ By musicamante https://stackoverflow.com/a/72673580/18396947"""
         opt = QStyleOptionTabWidgetFrame()
         self.initStyleOption(opt)
         return self.style().sizeFromContents(
-            QStyle.CT_TabWidget, opt, baseSize, self)
+            QStyle.ContentsType.CT_TabWidget, opt, baseSize, self)
 
     def sizeHint(self):
         return self.minimumSizeHint()
+
+
+class ScrollTabWidget(AdjustedTabWidget):
+    """AdjustedTabWidget where each tab contains a QScrollArea"""
+    def __init__(self, parent=None):
+        AdjustedTabWidget.__init__(self, parent)
+
+    def addTab(self, widget, name):
+        scroll = QScrollArea()
+        scroll.setWidget(widget)
+        scroll.setWidgetResizable(True)
+        AdjustedTabWidget.addTab(self, scroll, name)
+
+
+class AdjustedStackedWidget(QStackedWidget):
+    """QStackedWidget descendent whose size adjusts to fit the current
+widget."""
+    def __init__(self, parent=None):
+        QStackedWidget.__init__(self, parent)
+
+    def minimumSizeHint(self):
+        current_widget = self.currentWidget()
+        if self.count() < 0 or not current_widget:
+            return super().sizeHint()
+
+        current_widget.setMinimumSize(current_widget.sizeHint())
+        baseSize = current_widget.sizeHint().expandedTo(
+            current_widget.minimumSize())
+
+        return baseSize
+
+    def sizeHint(self):
+        return self.minimumSizeHint()
+
+
+class ScrollingStackedWidget(QScrollArea):
+    """AdjustedStackedWidget in a QScrollArea"""
+    def __init__(self, parent=None):
+        QWidget.__init__(self, parent)
+        self.stack = AdjustedStackedWidget()
+        self.setWidget(self.stack)
+        self.setWidgetResizable(True)
+
+    def addWidget(self, *args):
+        self.stack.addWidget(*args)
+
+    def setCurrentWidget(self, *args):
+        self.stack.setCurrentWidget(*args)
+
+
+class WrappedLabel(QWidget):
+    """Workaround for word-wrapped QLabel size constraint bug.
+Adapted from musicamante https://stackoverflow.com/a/70757504/18396947"""
+    def __init__(self, text, parent=None):
+        super().__init__(parent)
+        lyt = QHBoxLayout(self)
+        self.label = QLabel(text)
+        self.label.setWordWrap(True)
+        lyt.addWidget(self.label)
+        lyt.setContentsMargins(0, 0, 0, 0)
+        lyt.setSpacing(0)
+        self.setContentsMargins(0, 0, 0, 0)
+        self.doc = QTextDocument(text, self)
+        self.doc.setDocumentMargin(0)
+        self.doc.setDefaultFont(self.label.font())
+
+    def minimumSizeHint(self):
+        self.doc.setTextWidth(self.label.width())
+        height = self.doc.size().height()
+        height += self.label.frameWidth() * 2
+        return QSize(50, height)
+
+    def sizeHint(self):
+        return self.minimumSizeHint()
+
+    def resizeEvent(self, event):
+        super().resizeEvent(event)
+        self.updateGeometry()
+
+    def hasHeightForWidth(self):
+        """Without this, the sizeHint seems to be ignored"""
+        return False

--- a/retype/ui/customisation_dialog.py
+++ b/retype/ui/customisation_dialog.py
@@ -18,7 +18,7 @@ from retype.services.theme import Theme, populateThemes, valuesFromQss
 from retype.extras.qss import serialiseValuesDict
 from retype.resource_handler import getStylePath
 from retype.extras.widgets import (ScrollTabWidget, AdjustedStackedWidget,
-                                   WrappedLabel)
+                                   WrappedLabel, MinWidget)
 from retype.extras.camel import spacecamel
 
 logger = logging.getLogger(__name__)
@@ -172,7 +172,7 @@ class CustomisationDialog(QDialog):
         return pth
 
     def _consoleSettings(self):
-        pcon = QWidget()
+        pcon = MinWidget(200, height=False)
         lyt = QFormLayout(pcon)
 
         # prompt
@@ -195,7 +195,7 @@ class CustomisationDialog(QDialog):
         if iswindows:
             lyt.addRow(hline())
             hide_sysconsole_checkbox = CheckBox(
-                "Hide System Console window on UI load (Windows-only)")
+                "Hide System Console window on UI load\n(Windows-only)")
             hide_sysconsole_checkbox.setChecked(
                 self.config_edited.get('hide_sysconsole', True))
             hide_sysconsole_checkbox.changed.connect(
@@ -203,6 +203,7 @@ class CustomisationDialog(QDialog):
             self.selectors['hide_sysconsole'] = hide_sysconsole_checkbox
             lyt.addRow(hide_sysconsole_checkbox)
 
+        pcon.setMinimumWidth(50)
         return pcon
 
     def _sdictSettings(self):
@@ -1114,6 +1115,12 @@ class BookViewSettingsWidget(QWidget):
             value = settings[key]
             selector.setValue(value)
 
+    def minimumSizeHint(self):
+        return QSize(100, 100)
+
+    def sizeHint(self):
+        return self.minimumSizeHint()
+
 
 class _CEdit(QWidget):
     changed = pyqtSignal()
@@ -1409,6 +1416,12 @@ class ThemeWidget(QWidget):
             return
         # Write to file in path
         self._save(file_path, res)
+
+    def minimumSizeHint(self):
+        return QSize(100, 100)
+
+    def sizeHint(self):
+        return self.minimumSizeHint()
 
 
 class CategoriesDelegate(QItemDelegate):

--- a/retype/ui/customisation_dialog.py
+++ b/retype/ui/customisation_dialog.py
@@ -141,7 +141,6 @@ class CustomisationDialog(QDialog):
 
         preset_lyt = QHBoxLayout()
         themes = QComboBox()
-        themes.setInsertPolicy(QComboBox.InsertPolicy.InsertAlphabetically)
         preset_lyt.addWidget(themes, 1)
         apply_btn = QPushButton("Apply")
         apply_btn.setToolTip("Apply selected preset")
@@ -160,6 +159,7 @@ class CustomisationDialog(QDialog):
         for t in Theme.themes:
             if t != THEME_MODIFICATIONS_FILENAME.rstrip('.qss'):
                 themes.addItem(t)
+        themes.model().sort(0)
 
         t = ThemeWidget(user_dir)
         self.theme = t

--- a/retype/ui/customisation_dialog.py
+++ b/retype/ui/customisation_dialog.py
@@ -3,20 +3,22 @@ import logging
 from copy import deepcopy
 from base64 import b64encode
 from qt import (QWidget, QFormLayout, QVBoxLayout, QLabel, QLineEdit,
-                QHBoxLayout, QFrame, QPushButton, QToolBox, QCheckBox,
+                QHBoxLayout, QFrame, QPushButton, QCheckBox,
                 QSpinBox, QListView, QToolButton, QDialogButtonBox,
                 QAbstractListModel, Qt, QStyledItemDelegate, QStyle,
                 QApplication, QRectF, QTextDocument, QFileDialog, pyqtSignal,
                 QModelIndex, QItemSelectionModel, QMessageBox, QDialog, QSize,
                 QFont, QFontComboBox, QComboBox, QPainter, QBrush,
-                QColorDialog, QColor)
+                QColorDialog, QColor, QTreeView, QStandardItemModel,
+                QAbstractItemView, QItemDelegate, QStandardItem, QSizePolicy)
 
 from retype.extras.dict import SafeDict, update
 from retype.constants import default_config, iswindows
 from retype.services.theme import Theme, populateThemes, valuesFromQss
 from retype.extras.qss import serialiseValuesDict
 from retype.resource_handler import getStylePath
-from retype.extras.widgets import AdjustedTabWidget
+from retype.extras.widgets import (ScrollTabWidget, AdjustedStackedWidget,
+                                   WrappedLabel)
 from retype.extras.camel import spacecamel
 
 logger = logging.getLogger(__name__)
@@ -49,9 +51,7 @@ def npxspinbox(value):
 
 
 def descl(text):
-    desc = QLabel(text)
-    desc.setWordWrap(True)
-    return desc
+    return WrappedLabel(text)
 
 
 class CustomisationDialog(QDialog):
@@ -75,7 +75,7 @@ class CustomisationDialog(QDialog):
         self.setWindowTitle("Customise retype")
 
     def sizeHint(self):
-        return QSize(400, 500)
+        return QSize(500, 500)
 
     def getUserDir(self):
         return self.config['user_dir']
@@ -83,17 +83,18 @@ class CustomisationDialog(QDialog):
     def _initUI(self):
         self.selectors = {}
 
-        tbox = QToolBox()
-        tbox.addItem(self._pathSettings(), "Paths")
-        tbox.addItem(self._themeSettings(), "Theme")
-        tbox.addItem(self._consoleSettings(), "Console")
-        tbox.addItem(self._bookviewSettings(), "Book View")
-        tbox.addItem(self._sdictSettings(), "Line splits")
-        tbox.addItem(self._rdictSettings(), "Replacements")
-        tbox.addItem(self._windowSettings(), "Window geometry")
+        catw = CategorisedWidget()
+        catw.add("Filesystem", "Paths", self._pathSettings())
+        catw.add("User interface", "Theme", self._themeSettings())
+        catw.add("User interface", "Console", self._consoleSettings())
+        catw.add("User interface", "Book View", self._bookviewSettings())
+        catw.add("User interface", "Window geometry", self._windowSettings())
+        catw.add("Behaviour", "Line splits", self._sdictSettings())
+        catw.add("Behaviour", "Replacements", self._rdictSettings())
+        catw.postAddingCategories()
 
         lyt = QVBoxLayout(self)
-        lyt.addWidget(tbox)
+        lyt.addWidget(catw)
         lyt.addWidget(hline())
         self.revert_btn = QPushButton("Revert")
         self.revert_btn.setToolTip("Revert changes")
@@ -1259,7 +1260,7 @@ class ThemeWidget(QWidget):
         self.values = self._loadValues(getStylePath(user_dir))
         self.lyt = QVBoxLayout(self)
         self.lyt.setContentsMargins(0, 0, 0, 0)
-        self.tabw = AdjustedTabWidget()
+        self.tabw = ScrollTabWidget()
         self.lyt.addWidget(self.tabw)
         self._populateWidgets()
 
@@ -1408,3 +1409,106 @@ class ThemeWidget(QWidget):
             return
         # Write to file in path
         self._save(file_path, res)
+
+
+class CategoriesDelegate(QItemDelegate):
+    def __init__(self, parent=None):
+        QItemDelegate.__init__(self, parent)
+        self.row_height = 24
+
+    def drawDisplay(self, painter, option, rect, text):
+        newoption = option
+        if not option.state & QStyle.StateFlag.State_Enabled:  # Sections
+            painter.fillRect(rect, option.palette.window().color().darker(106))
+            painter.setPen(option.palette.window().color().darker(130))
+            if rect.top():
+                painter.drawLine(rect.topRight(), rect.topLeft())
+            painter.drawLine(rect.bottomRight(), rect.bottomLeft())
+
+            newoption.displayAlignment = Qt.AlignmentFlag.AlignCenter
+
+            # Fake enabled state
+            newoption.state |= newoption.state | QStyle.StateFlag.State_Enabled
+        else:
+            option.font.setWeight(QFont.Bold)
+
+        QItemDelegate.drawDisplay(self, painter, newoption, rect, text)
+
+    def sizeHint(self, option, index):
+        size = QItemDelegate.sizeHint(self, option, index)
+        size.setHeight(self.row_height)
+        return size
+
+
+class CategoriesTree(QTreeView):
+    def __init__(self, parent=None):
+        QWidget.__init__(self, parent)
+        self.setContentsMargins(0, 0, 0, 0)
+        self.setIndentation(0)
+        self.setHeaderHidden(True)
+        self.setRootIsDecorated(False)
+        self.setItemsExpandable(False)
+        self.header().setVisible(False)
+        self.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
+        self.setItemDelegate(CategoriesDelegate(self))
+
+        self.model = QStandardItemModel(self)
+        self.setModel(self.model)
+
+        self.data_role = Qt.ItemDataRole.UserRole
+
+        self.setSizePolicy(QSizePolicy.Policy.Fixed,
+                           QSizePolicy.Policy.Preferred)
+
+    def sizeHint(self):
+        size = QTreeView.sizeHint(self)
+        size.setWidth(130)
+        return size
+
+    def addSection(self, name):
+        section = QStandardItem(name)
+        section.setFlags(Qt.ItemFlag.NoItemFlags)
+        self.model.appendRow(section)
+        return section
+
+    def addCategory(self, section, name, data=None):
+        category = QStandardItem(f'  {name}')
+        if data is not None:
+            category.setData(data, self.data_role)
+        section.appendRow(category)
+        category.setFlags(Qt.ItemFlag.ItemIsEnabled |
+                          Qt.ItemFlag.ItemIsSelectable)
+
+    def postAddingCategories(self):
+        self.expandAll()
+        self.setCurrentIndex(self.model.index(0, 0, self.model.index(0, 0)))
+        self.setFocus(Qt.FocusReason.NoFocusReason)
+
+    def dataFromIndex(self, index):
+        return self.model.itemFromIndex(index).data(self.data_role)
+
+
+class CategorisedWidget(QWidget):
+    def __init__(self, parent=None):
+        QWidget.__init__(self, parent)
+        self.tree = CategoriesTree()
+        self.stack = AdjustedStackedWidget()
+        self.sections = {}
+        self.tree.selectionModel().currentChanged.connect(self.switchCategory)
+        lyt = QHBoxLayout(self)
+        lyt.addWidget(self.tree)
+        lyt.addWidget(self.stack)
+        lyt.setContentsMargins(0, 0, 0, 0)
+
+    def add(self, section_name, category_name, widget):
+        if section_name not in self.sections:
+            self.sections[section_name] = self.tree.addSection(section_name)
+        self.tree.addCategory(
+            self.sections[section_name], category_name, widget)
+        self.stack.addWidget(widget)
+
+    def postAddingCategories(self):
+        self.tree.postAddingCategories()
+
+    def switchCategory(self, index):
+        self.stack.setCurrentWidget(self.tree.dataFromIndex(index))

--- a/style/0_default.qss
+++ b/style/0_default.qss
@@ -16,24 +16,6 @@ QSplitter::handle {
   background: url(style:stripe.png) repeat;
 }
 
-QToolBox::tab {
-  background: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
-                              stop: 0 #E1E1E1, stop: 0.4 #DDDDDD,
-                              stop: 0.5 #D8D8D8, stop: 1.0 #D3D3D3);
-  border-radius: 5px;
-  color: black;
-  font-weight: bold;
-}
-
-QToolBox::tab:selected {
-  font-style: italic;
-}
-
-QToolBox::tab:hover {
-  color: red;
-  font-style: italic;
-}
-
 QToolBar {
   padding: 0;
 }


### PR DESCRIPTION
Less cramped customisation dialog UI, with each category in a separate page selected via a sidebar instead of in a QToolBox. It was already too cramped and adding more categories would have cramped it further. With this new set up as many more categories as needed can be added without negatively affecting usability.

Before:
![customisation dialog pre-sidebar](https://github.com/plu5/retype/assets/8400561/d2d90da9-4e73-47b5-a683-e3323dbb4f06)

After:
![customisation dialog post-sidebar](https://github.com/plu5/retype/assets/8400561/9b0d532f-72bf-4f2c-8127-7dcb7962b9c2)
