### PR TITLE
fix(UI): Shelf View book idn positioning

### DIFF
--- a/retype/ui/painting.py
+++ b/retype/ui/painting.py
@@ -52,14 +52,27 @@ def rectPixmap(w, h, fg=white, bg=transparent):
 
 
 def textPixmap(text, w, h, font, fg=white,
-               alignment=center | wordwrap):
+               alignment=center | wordwrap, bounding_rect=None):
     pixmap = QPixmap(w, h)
     pixmap.fill(transparent)
-    qp = QPainter(pixmap)
+    # On some versions of Qt there is a last optional argument to drawText to
+    #  give the bounding rect, but my version doesn't, so draw it in an inner
+    #  pixmap.
+    qp = inner_pixmap = None
+    if bounding_rect:
+        inner_pixmap = QPixmap(w, h)
+        inner_pixmap.fill(transparent)
+        qp = QPainter(inner_pixmap)
+    else:
+        qp = QPainter(pixmap)
+        bounding_rect = QRectF(0, 0, w, h)
     font = font.toQFont() if type(font) == Font else font
     qp.setFont(font)
     qp.setPen(fg)
-    qp.drawText(QRectF(0, 0, w, h), alignment, text)
+    qp.drawText(bounding_rect, alignment, text)
+    if inner_pixmap:
+        qp = QPainter(pixmap)
+        qp.drawPixmap(0, 0, inner_pixmap)
     return pixmap
 
 

--- a/retype/ui/shelf_view.py
+++ b/retype/ui/shelf_view.py
@@ -1,6 +1,6 @@
 import logging
 from qt import (QWidget, QVBoxLayout, QPainter, Qt, QColor, QEvent, QPixmap,
-                QSize)
+                QSize, QFont, QFontMetrics)
 
 from retype.layouts import ShelvesWidget
 from retype.ui import Cover
@@ -165,30 +165,60 @@ class ShelfItem(QWidget):
 class IDNDisplay(QWidget):
     def __init__(self, idn, w):
         super().__init__()
-        self.idn = idn
-        self.w = w
+        self._idn = idn
+        self._font = Font.GENERAL
+        self._w = w
+        self._h = 0
         self.c = self._loadTheme()
+        self._pixmap = self.pixmap()
+
+    def regenPixmap(self):
+        self._pixmap = self.pixmap()
+
+    @property
+    def idn(self):
+        return self._idn
+
+    @idn.setter
+    def idn(self, value):
+        self._idn = value
+        self.regenPixmap()
+
+    @property
+    def font(self):
+        return self._font
+
+    @font.setter
+    def font(self, value):
+        self._font = value
+        self.regenPixmap()
+
+    @property
+    def w(self):
+        return self._w
+
+    @w.setter
+    def w(self, value):
+        self._w = value
+        self.regenPixmap()
 
     def _loadTheme(self):
         return Theme.get('ShelfView.IDNDisplay')
 
-    def pixmap(self, idn):
-        (w, h) = (self.w, 10)
-        pixmap = QPixmap(w, h)
-        pixmap.fill(QColor('transparent'))
-        qp = QPainter(pixmap)
-        font = Font.GENERAL
-        qp.drawPixmap(0, -3,
-                      textPixmap(str(idn), w, 20, font, self.c.fg(),
-                                 Qt.AlignmentFlag.AlignHCenter))
-        return pixmap
+    def pixmap(self):
+        font = self._font.toQFont()
+        fm = QFontMetrics(font)
+        self._h = fm.height()
+        (w, h) = (self._w, self._h)
+        return textPixmap(str(self._idn), w, h, font, self.c.fg(),
+                          Qt.AlignmentFlag.AlignHCenter)
 
     def paintEvent(self, e):
         qp = QPainter(self)
-        qp.drawPixmap(0, 0, self.pixmap(self.idn))
+        qp.drawPixmap(0, 0, self._pixmap)
 
     def sizeHint(self):
-        return QSize(self.w, 10)
+        return QSize(self._w, self._h)
 
 
 @theme('ShelfView.ProgressBar', C(fg='yellow', bg='black'))

--- a/retype/ui/shelf_view.py
+++ b/retype/ui/shelf_view.py
@@ -1,6 +1,6 @@
 import logging
 from qt import (QWidget, QVBoxLayout, QPainter, Qt, QColor, QEvent, QPixmap,
-                QSize, QFont, QFontMetrics)
+                QSize, QFontMetrics, QRectF)
 
 from retype.layouts import ShelvesWidget
 from retype.ui import Cover
@@ -150,7 +150,6 @@ class ShelfItem(QWidget):
         self.layout_ = QVBoxLayout(self)
         self.layout_.setContentsMargins(0, 0, 0, 0)
         self.layout_.setSpacing(0)
-        self.setLayout(self.layout_)
         self.layout_.addWidget(IDNDisplay(self.idn, self.cover.width))
         self.layout_.addWidget(self.cover)
         self.progress_bar = ProgressBar(self.cover.width, self.progress)
@@ -166,52 +165,26 @@ class IDNDisplay(QWidget):
     def __init__(self, idn, w):
         super().__init__()
         self._idn = idn
-        self._font = Font.GENERAL
+        self._font = Font.GENERAL.toQFont()
         self._w = w
-        self._h = 0
+        self._h = 20
+        self._bottom_margin = 2
         self.c = self._loadTheme()
         self._pixmap = self.pixmap()
-
-    def regenPixmap(self):
-        self._pixmap = self.pixmap()
-
-    @property
-    def idn(self):
-        return self._idn
-
-    @idn.setter
-    def idn(self, value):
-        self._idn = value
-        self.regenPixmap()
-
-    @property
-    def font(self):
-        return self._font
-
-    @font.setter
-    def font(self, value):
-        self._font = value
-        self.regenPixmap()
-
-    @property
-    def w(self):
-        return self._w
-
-    @w.setter
-    def w(self, value):
-        self._w = value
-        self.regenPixmap()
 
     def _loadTheme(self):
         return Theme.get('ShelfView.IDNDisplay')
 
     def pixmap(self):
-        font = self._font.toQFont()
+        font = self._font
         fm = QFontMetrics(font)
-        self._h = fm.height()
-        (w, h) = (self._w, self._h)
-        return textPixmap(str(self._idn), w, h, font, self.c.fg(),
-                          Qt.AlignmentFlag.AlignHCenter)
+        descent = fm.descent()
+        bounding_rect = QRectF(
+            0, 0, self._w, self._h + descent - self._bottom_margin)
+        return textPixmap(
+            str(self._idn), self._w, self._h, font, self.c.fg(),
+            Qt.AlignmentFlag.AlignHCenter | Qt.AlignmentFlag.AlignBottom,
+            bounding_rect)
 
     def paintEvent(self, e):
         qp = QPainter(self)


### PR DESCRIPTION
The `idn`s above the books in Shelf View were being drawn too low and getting clipped with certain fonts. I have changed the drawing logic to have a consistent position regardless of font used.