### PR TITLE
fix: Customisation Dialog RDict/SDict readability

### DIFF
--- a/retype/ui/customisation_dialog.py
+++ b/retype/ui/customisation_dialog.py
@@ -14,7 +14,8 @@ from qt import (QWidget, QFormLayout, QVBoxLayout, QLabel, QLineEdit,
 
 from retype.extras.dict import SafeDict, update
 from retype.constants import default_config, iswindows
-from retype.services.theme import Theme, populateThemes, valuesFromQss
+from retype.services.theme import (Theme, populateThemes, valuesFromQss, theme,
+                                   C)
 from retype.extras.qss import serialiseValuesDict
 from retype.resource_handler import getStylePath
 from retype.extras.widgets import (ScrollTabWidget, AdjustedStackedWidget,
@@ -693,7 +694,10 @@ Keep: <code><b>{2}</b></code></p>'''
         return False
 
 
+@theme('CustomisationDialog.SDict.EntryEditor', C(fg='black', bg='#CDE8FF'))
 class SDictEntryEditor(QWidget):
+    selector = 'CustomisationDialog.SDict.EntryEditor'
+
     def __init__(self, substr, keep, parent=None):
         QWidget.__init__(self, parent)
 
@@ -704,7 +708,10 @@ class SDictEntryEditor(QWidget):
         lyt.addRow("Substring:", self.substr_e)
         lyt.addRow("Keep:", self.keep_e)
 
-        self.setStyleSheet("color:black;background-color:#CDE8FF")
+        # Note: No need to connect to selector change; this editor gets created
+        #  and destroyed each time it opens/closes, it does not persist
+        self.themeUpdate()
+
         self.setAttribute(Qt.WA_StyledBackground, True)
 
         lyt.setContentsMargins(0, 0, 0, 0)
@@ -715,6 +722,10 @@ class SDictEntryEditor(QWidget):
 
     def keep(self):
         return {'keep': self.keep_e.isChecked()}
+
+    def themeUpdate(self):
+        qss = Theme.getQss(self.selector).replace(self.selector, 'QWidget')
+        self.setStyleSheet(qss)
 
 
 class SDictDelegate(Delegate):
@@ -867,7 +878,10 @@ Replacements list: <code><b>{2}</b></code></p>'''
         return False
 
 
+@theme('CustomisationDialog.RDict.EntryEditor', C(fg='black', bg='#CDE8FF'))
 class RDictEntryEditor(QWidget):
+    selector = 'CustomisationDialog.RDict.EntryEditor'
+
     def __init__(self, substr, reps, parent=None):
         QWidget.__init__(self, parent)
 
@@ -877,7 +891,10 @@ class RDictEntryEditor(QWidget):
         lyt.addRow("Substring:", self.substr_e)
         lyt.addRow("Replacements (separated by ,):", self.reps_e)
 
-        self.setStyleSheet("color:black;background-color:#CDE8FF")
+        # Note: No need to connect to selector change; this editor gets created
+        #  and destroyed each time it opens/closes, it does not persist
+        self.themeUpdate()
+
         self.setAttribute(Qt.WA_StyledBackground, True)
 
         lyt.setContentsMargins(0, 0, 0, 0)
@@ -888,6 +905,10 @@ class RDictEntryEditor(QWidget):
 
     def reps(self):
         return self.reps_e.text().split(',')
+
+    def themeUpdate(self):
+        qss = Theme.getQss(self.selector).replace(self.selector, 'QWidget')
+        self.setStyleSheet(qss)
 
 
 class RDictDelegate(Delegate):

--- a/retype/ui/customisation_dialog.py
+++ b/retype/ui/customisation_dialog.py
@@ -704,8 +704,7 @@ class SDictEntryEditor(QWidget):
         lyt.addRow("Substring:", self.substr_e)
         lyt.addRow("Keep:", self.keep_e)
 
-        # Background
-        self.setStyleSheet("background-color:#CDE8FF")
+        self.setStyleSheet("color:black;background-color:#CDE8FF")
         self.setAttribute(Qt.WA_StyledBackground, True)
 
         lyt.setContentsMargins(0, 0, 0, 0)
@@ -878,8 +877,7 @@ class RDictEntryEditor(QWidget):
         lyt.addRow("Substring:", self.substr_e)
         lyt.addRow("Replacements (separated by ,):", self.reps_e)
 
-        # Background
-        self.setStyleSheet("background-color:#CDE8FF")
+        self.setStyleSheet("color:black;background-color:#CDE8FF")
         self.setAttribute(Qt.WA_StyledBackground, True)
 
         lyt.setContentsMargins(0, 0, 0, 0)

--- a/retype/ui/customisation_dialog.py
+++ b/retype/ui/customisation_dialog.py
@@ -620,7 +620,8 @@ class ListView(QListView):
 
 
 class SDictModel(QAbstractListModel):
-    TEMPLATE = '''<p><b>Substring:</b> <code>'<u style="color:blue">{0}</u>' ({1})</code><br>
+    TEMPLATE = '''<p><b>Substring:</b> <code>'<u style="color:palette(link)">\
+{0}</u>' ({1})</code><br>
 Keep: <code><b>{2}</b></code></p>'''
     INVALID_TEMPLATE = '<div style="color:red">' + TEMPLATE + '</div>'
     changed = pyqtSignal(dict)
@@ -698,7 +699,7 @@ class SDictEntryEditor(QWidget):
 
         lyt = QFormLayout(self)
         self.substr_e = QLineEdit(substr)
-        self.keep_e = CheckBox()
+        self.keep_e = CheckBox('')
         self.keep_e.setChecked(keep)
         lyt.addRow("Substring:", self.substr_e)
         lyt.addRow("Keep:", self.keep_e)
@@ -794,7 +795,8 @@ class SDictWidget(QWidget):
 
 
 class RDictModel(QAbstractListModel):
-    TEMPLATE = '''<p><b>Substring:</b> <code>'<u style="color:blue">{0}</u>' ({1})</code><br>
+    TEMPLATE = '''<p><b>Substring:</b> <code>'<u style="color:palette(link)">\
+{0}</u>' ({1})</code><br>
 Replacements list: <code><b>{2}</b></code></p>'''
     INVALID_TEMPLATE = '<div style="color:red">' + TEMPLATE + '</div>'
     changed = pyqtSignal(dict)


### PR DESCRIPTION
Customisation Dialog RDict/SDict substring colour and editor colours unreadable on dark OS

For the former issue changed to a palette colour, and for the latter still setting our own colours but setting foreground explicitly so that it remains readable, and also made these colours customisable in the theme.