### PR TITLE
perf: Highlighting memory usage

### DIFF
--- a/retype/console/highlighting_service.py
+++ b/retype/console/highlighting_service.py
@@ -44,10 +44,6 @@ class HighlightingService(object):
         if not self.valid(v):
             return
 
-        # Remove highlighting if things were deleted
-        if len(text) + v.persistent_pos < v.cursor_pos:
-            v.highlight_cursor.mergeCharFormat(v.unhighlight_format)
-
         # Cursor position in the line
         end_correctness_index = compareStrings(text, v.current_line)
         v.cursor_pos = v.persistent_pos + end_correctness_index

--- a/retype/ui/book_view.py
+++ b/retype/ui/book_view.py
@@ -342,6 +342,10 @@ class BookView(QWidget):
         self.highlight_sel.format = self.highlight_format
         self.display.setExtraSelections([self.highlight_sel])
 
+        # Also required to avoid ExtraSelections segfault when switching view,
+        # even if self.display.extraSelections() is an empty list
+        self.highlight_cursor.setPosition(0)
+
     def fillHighlight(self):
         self.setHighlightCursor()
         self.updateHighlightCursor(self.chapter_lens[self.viewed_chapter_pos])

--- a/style/0_default.qss
+++ b/style/0_default.qss
@@ -77,11 +77,6 @@ BookView.Highlighting.Mistake {
   background-color: #ff0000;
 }
 
-BookView.Highlighting.Unhighlight {
-  color: #000000;
-  background-color: #ffffff;
-}
-
 BookView.Highlighting.Highlight {
   color: #000000;
   background-color: #ffff00;

--- a/style/dark.qss
+++ b/style/dark.qss
@@ -49,11 +49,6 @@ BookView.Highlighting.Mistake {
   background-color: #ff0000;
 }
 
-BookView.Highlighting.Unhighlight {
-  color: #ffffff;
-  background-color: #000000;
-}
-
 BookView.Highlighting.Highlight {
   color: #ffffff;
   background-color: #757500;

--- a/tests/test_highlighting_service.py
+++ b/tests/test_highlighting_service.py
@@ -54,7 +54,6 @@ class FakeBookView(QObject):
         self.progress = 0
 
         self.highlight_format = QTextCharFormat()
-        self.unhighlight_format = QTextCharFormat()
         self.mistake_format = QTextCharFormat()
 
         self.cursor = QTextCursor(self.display.document())


### PR DESCRIPTION
It turns out that calling `mergeCharFormat` repeatedly is expensive. Memory usage goes up with every call, with the only way I found to decrease it being `setDocument` to reset everything. Setting a blank char format doesn't do it.

`setExtraSelections` exists and seems to do the job with a significantly lower footprint. It does have at least one nasty bug where it [causes a segfault](https://stackoverflow.com/questions/73776460/qt-6-crash-in-qplaintextsetextraselections-after-qplaintextsetdocument) if you `setDocument` with existing extra selections, so I want to thoroughly test this on all operating systems before merging.

Qt is a pain sometimes :-(

E: This also means getting rid of the unhighlighting format, as with `setExtraSelections` there's no need for that.

Also the mistake highlighting still uses `mergeCharFormat` because in profiling I saw no performance benefits to switching that, so it would increase complexity for no noticeable gain.