### PR TITLE
refactor: Lazy autosave construction + unmark dirty on save

### DIFF
--- a/retype/games/steno.py
+++ b/retype/games/steno.py
@@ -315,7 +315,6 @@ class StenoView(BookView):
         self.return_entry = '0'
         self.visual_kbd = VisualStenoKeyboard(self.kdict, self._console, self)
         self.stats_dock.deleteLater()
-        self.autosave.deleteLater()
         self.splitter.addWidget(self.visual_kbd)
         self.stage = None  # type: Stage | None
         self.timer = QTimer(self)

--- a/retype/games/typespeed.py
+++ b/retype/games/typespeed.py
@@ -533,7 +533,6 @@ class TypespeedView(BookView):
         self.skip_action.setDisabled(True)
         self.return_entry = '0'
         self.stats_dock.deleteLater()
-        self.autosave.deleteLater()
 
         # modeline adjustments
         self.modeline.pos_sep.setText(" ")

--- a/retype/ui/book_view.py
+++ b/retype/ui/book_view.py
@@ -149,8 +149,7 @@ class BookView(QWidget):
         self._controller = main_controller
         self._library = self._controller.library
         self._console = self._controller.console
-        self.autosave = Autosave(self._console)
-        self.autosave.save.connect(self.maybeSave)
+        self.autosave = None  # type: Autosave | None
 
         bookview_settings = bookview_settings or {}
         self.display = BookDisplay(
@@ -463,6 +462,10 @@ class BookView(QWidget):
 
         if not self.stats_dock.connected:
             self.stats_dock.connectConsole(self._controller.console)
+
+        if self.autosave is None:
+            self.autosave = Autosave(self._console)
+            self.autosave.save.connect(self.maybeSave)
 
         complete = book.progress == 100
 

--- a/retype/ui/book_view.py
+++ b/retype/ui/book_view.py
@@ -622,6 +622,7 @@ class BookView(QWidget):
                     'chapter_pos': self.chapter_pos,
                     'progress': self.progress}  # type: SaveData
             self._library.save(self.book, data)  # type: ignore[arg-type]
+            self.book.dirty = False
 
     def switchToShelves(self):
         # type: (BookView) -> None


### PR DESCRIPTION
- Autosave timer procs needlessly  if switching to `BookView` with no book loaded
- `book.dirty` flag needs to be set back to `False` after save
- Remember retype can only save "persistent pos", which only changes if line has changed, so `book.dirty` does not need to be set to `True` for every change, only if line changed (where line is not strictly newline but whatever is configured in linesplits)