### PR TITLE
fix(StatsDock): WPM/PB text clipping

### DIFF
--- a/retype/stats/stats_dock.py
+++ b/retype/stats/stats_dock.py
@@ -1,4 +1,4 @@
-from math import floor
+from math import floor, ceil
 from time import time
 from qt import QWidget, QPainter, Qt, QSize, QFontMetricsF
 
@@ -135,13 +135,13 @@ class StatsDock(QWidget):
         # Text
         font = Font.GENERAL.toQFont()
         fm = QFontMetricsF(font)
-        font_h = int(fm.height())
+        font_h = ceil(fm.height())
         pb_txt = "PB: {}".format(self.wpm_pb)
         cur_txt = "Current: {} WPM".format(self.wpm)
         draw(2, 2,
-             textPixmap(pb_txt, int(fm.horizontalAdvance(pb_txt)), font_h,
+             textPixmap(pb_txt, ceil(fm.horizontalAdvance(pb_txt)), font_h,
                         font, self.text_c.fg()))
-        cur_w = int(fm.horizontalAdvance(cur_txt))
+        cur_w = ceil(fm.horizontalAdvance(cur_txt))
         draw(w - cur_w - 2, 2,
              textPixmap(cur_txt, cur_w, font_h, font, self.text_c.fg()))
 


### PR DESCRIPTION
I think this was introduced when fixing the floats issue (Python 3.10 ints and floats no longer compatible). Converting to ints with `int()` in this situation is not the right thing to do; need to round up. So all I've done here is changed it to use `ceil()`.