### PR TITLE
feat: Painted-over highlight (#1)

### DIFF
--- a/retype/console/highlighting_service.py
+++ b/retype/console/highlighting_service.py
@@ -182,7 +182,6 @@ error: {}'.format(v.line_pos, len(v.tobetyped_list), e))
         # type: (HighlightingService) -> None
         v = self.book_view
         v.updateCursorPosition()
-        v.updateHighlightCursor()
 
         if self.wrong:
             v.mistake_cursor.mergeCharFormat(v.mistake_format)

--- a/retype/games/steno.py
+++ b/retype/games/steno.py
@@ -461,7 +461,6 @@ class StenoView(BookView):
     def updateHighlighting(self):
         # type: (StenoView) -> None
         self.updateCursorPosition()
-        self.updateHighlightCursor()
         self.updateModeline()
 
     def _handleMistakes(self, v, text, end_correctness_index):

--- a/retype/services/theme.py
+++ b/retype/services/theme.py
@@ -62,8 +62,6 @@ class C(QObject):
 class Theme:
     selectors = {}  # type: dict[str, C]
     themes = {}  # type: dict[str, ThemeData]
-    # ^ Theme.themes[name] = {'path': p, 'values': values}
-    # TEMP: dict[str, dict[str, str | ValuesDict]]
 
     @staticmethod
     def get(selector_name):

--- a/retype/ui/book_view.py
+++ b/retype/ui/book_view.py
@@ -394,14 +394,7 @@ class BookView(QWidget):
         self.updateCursorPosition()
         self.display.setCursor(self._cursor)
 
-        self.setHighlightCursor()
-
         self.setMistakeCursor()
-
-    def setHighlightCursor(self):
-        # type: (BookView) -> None
-        self.highlight_cursor = QTextCursor(self.display.document())
-        self.updateHighlightCursor()
 
     def setMistakeCursor(self):
         # type: (BookView) -> None
@@ -417,12 +410,7 @@ class BookView(QWidget):
         pos = to_pos or self.cursor_pos
         self._cursor.setPosition(pos)
 
-    def updateHighlightCursor(self, to_pos=None):
-        # type: (BookView, int | None) -> None
-        if self.cursor_pos is None:
-            return
-        pos = to_pos or self.cursor_pos
-        self.highlight_cursor.setPosition(pos, self._cursor.KeepAnchor)
+        # Update highlighting
         self.display.full_highlight = False
         self.display.update()
 

--- a/retype/ui/book_view.py
+++ b/retype/ui/book_view.py
@@ -409,16 +409,12 @@ class BookView(QWidget):
             return
         pos = to_pos or self.cursor_pos
         self._cursor.setPosition(pos)
+        self.highlight(full=False)
 
-        # Update highlighting
-        self.display.full_highlight = False
+    def highlight(self, full=False):
+        # type: (BookView, bool) -> None
+        self.display.full_highlight = full
         self.display.update()
-
-    def fillHighlight(self):
-        # type: (BookView) -> None
-        if self.chapter_lens is None:
-            return
-        self.display.full_highlight = True
 
     def setSource(self, chapter):
         # type: (BookView, Chapter) -> None
@@ -496,7 +492,7 @@ class BookView(QWidget):
         elif pos == self.chapter_pos:
             self.setCursor()
         elif pos < self.chapter_pos:
-            self.fillHighlight()
+            self.highlight(full=True)
         self.updateModeline()
         self.display.updateFont()
         self.updateToolbarActions()

--- a/retype/ui/customisation_dialog.py
+++ b/retype/ui/customisation_dialog.py
@@ -8,7 +8,7 @@ from qt import (QWidget, QFormLayout, QVBoxLayout, QLabel, QLineEdit,
                 QAbstractListModel, Qt, QStyledItemDelegate, QStyle,
                 QApplication, QRectF, QTextDocument, QFileDialog, pyqtSignal,
                 QModelIndex, QItemSelectionModel, QMessageBox, QDialog, QSize,
-                QFont, QFontComboBox, QComboBox, QPainter, QBrush,
+                QFont, QFontComboBox, QComboBox, QPainter,
                 QColorDialog, QColor, QTreeView, QStandardItemModel,
                 QAbstractItemView, QItemDelegate, QStandardItem, QSizePolicy)
 
@@ -1698,12 +1698,14 @@ class _CEdit(QWidget):
     def paintEvent(self, event=None):
         # type: (_CEdit, QPaintEvent | None) -> None
         painter = QPainter(self)
-        painter.setBrush(QBrush(self.current_c))
+        painter.setBrush(self.current_c)
         painter.drawRect(self.rect())
 
     def mouseReleaseEvent(self, e):
         # type: (_CEdit, QMouseEvent) -> None
-        res = QColorDialog.getColor(self.current_c)
+        res = QColorDialog.getColor(
+            self.current_c,
+            options=QColorDialog.ColorDialogOption.ShowAlphaChannel)
         if res.isValid():
             self.set_(res)
 
@@ -1813,7 +1815,9 @@ class ThemeSelectorWidget(QWidget):
         # type: (ThemeSelectorWidget) -> dict[str, str]
         values = {}
         for prop_name, cedit in self.cedits.items():
-            values[prop_name] = cedit.current_c.name()
+            fmt = (QColor.NameFormat.HexArgb if cedit.current_c.alpha() < 255
+                   else QColor.NameFormat.HexRgb)
+            values[prop_name] = cedit.current_c.name(fmt)
         return values
 
 

--- a/style/0_default.qss
+++ b/style/0_default.qss
@@ -78,8 +78,7 @@ BookView.Highlighting.Mistake {
 }
 
 BookView.Highlighting.Highlight {
-  color: #000000;
-  background-color: #ffff00;
+  background-color: #40ffff00;
 }
 
 ShelfView.Top {

--- a/style/dark.qss
+++ b/style/dark.qss
@@ -50,8 +50,7 @@ BookView.Highlighting.Mistake {
 }
 
 BookView.Highlighting.Highlight {
-  color: #ffffff;
-  background-color: #757500;
+  background-color: #30ffff00;
 }
 
 ShelfView.Top {

--- a/tests/test_qss.py
+++ b/tests/test_qss.py
@@ -66,6 +66,11 @@ class TestQssGetCValue():
                         parseD('background-color: #qwer;'))
         assert res is None
 
+    def test_argb_cvalue(self):
+        res = getCValue('color',
+                        parseD('color: #80ffff00;'))
+        assert res == '#80ffff00'
+
 
 class TestSerialiseProp():
     def test_prop(self):

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -50,3 +50,9 @@ class TestThemeValuesFromQss:
              'test': {'t': None, 'color': None}}
         res = valuesFromQss(d, qss)
         assert res == {'test': {'t': 'red'}}
+
+    def test_argb_cvalue(self):
+        qss = "test{t:#80ffff00;}"
+        d = {'test': {'t': None}}
+        res = valuesFromQss(d, qss)
+        assert res == {'test': {'t': '#80ffff00'}}


### PR DESCRIPTION
This solves #1 (intentionally not saying fixes because I don't want it to automatically close it until it's actually solved in a release)

Instead of using charformats or extra selections, simply paint over the book display up to the cursor. This has the benefits of better performance and not having to work around Qt bugs.