### PR TITLE
refactor: "Fix" mypy 1.15 → 1.18.1 typechecking errors

### DIFF
--- a/retype/console/console.py
+++ b/retype/console/console.py
@@ -34,7 +34,7 @@ class Console(LineEdit):
         }  # type: dict[Console.Ev, list[Callable[[QKeyEvent], None]]]
 
         self._font = self.font()
-        self._font_family = self.font_family = font_family
+        self._font_family = font_family  # type: str | None
         self._prompt = prompt
 
         self.command_service = None  # type: CommandService | None

--- a/retype/extras/metatypes.py
+++ b/retype/extras/metatypes.py
@@ -8,7 +8,7 @@ from retype.games.typespeed import TypespeedView as TypespeedV
 from retype.games.steno import StenoView
 from retype.controllers.main_controller import View
 from retype.extras.dict import _NestedSafeDictGroup
-from qt import QWidget, pyqtSignal
+from qt import QWidget, pyqtBoundSignal
 
 NestedDict = Dict[object, Union[object, 'NestedDict']]
 NestedMapping = Mapping[object, Union[object, 'NestedMapping']]
@@ -164,6 +164,6 @@ class Book(Protocol):
 
 
 class Selector(Protocol, QWidget):  # type: ignore[misc]
-    changed: pyqtSignal
+    changed: pyqtBoundSignal
 
     def set_(self, value: object) -> None: ...

--- a/retype/extras/str_subclasses.py
+++ b/retype/extras/str_subclasses.py
@@ -110,7 +110,7 @@ class AnyStr(UserString):
         new = AnyStr(*self.possibilities)  # type: AnyStr | str
         for i in directions:
             if i == 1:
-                sl = slice(1, len(self))
+                sl = slice(1, len(self))  # type: ignore[misc]
                 k = 0
             elif i == -1:
                 sl = slice(0, -1)
@@ -120,7 +120,7 @@ class AnyStr(UserString):
 not {}".format(i))
             for char in chars:
                 while new and new[k] == char:
-                    new = new[sl]
+                    new = new[sl]  # type: ignore[misc]
         return new
 
     def lstrip(self, chars=" "):  # type: ignore[override]
@@ -281,7 +281,7 @@ class ManifoldStr(UserString):
                     if k < i:
                         substring, k = (self.manifold[k], k)
                         break
-                if substring is None:
+                if substring is None or k is None:
                     raise KeyError
                 return substring[i - k]
         elif isinstance(i, slice):  # type: ignore[misc]
@@ -323,7 +323,7 @@ class ManifoldStr(UserString):
         new = deepcopy(self)  # type: UserString | str
         for i in directions:
             if i == 1:
-                sl = slice(1, len(self))
+                sl = slice(1, len(self))  # type: ignore[misc]
                 k = 0
             elif i == -1:
                 sl = slice(0, -1)
@@ -333,7 +333,7 @@ class ManifoldStr(UserString):
 not {}".format(i))
             for char in chars:
                 while new and new[k] == char:
-                    new = new[sl]
+                    new = new[sl]  # type: ignore[misc]
         return new
 
     def lstrip(self, chars=" "):  # type: ignore[override]

--- a/retype/ui/cover.py
+++ b/retype/ui/cover.py
@@ -156,7 +156,7 @@ class Cover(QWidget):
         if self.pregenerated:
             self.pixmap = PregeneratedCover(*info).pixmap()
         self.hover_image = HoverCover(*info).pixmap()
-        self.complete_indicator = CompleteIndicator(*info[0:2]).pixmap()
+        self.complete_indicator = CompleteIndicator(info[0], info[1]).pixmap()
 
     def sizeHint(self):
         # type: (Cover) -> QSize

--- a/retype/ui/customisation_dialog.py
+++ b/retype/ui/customisation_dialog.py
@@ -99,10 +99,11 @@ class CustomisationDialog(QDialog):
         # type: (...) -> None
         QDialog.__init__(self, parent, Qt.WindowType.WindowCloseButtonHint)
         # The base config (no uncommitted modifications)
-        self.config = merge_dicts(DEFAULTS, config)  # type: Config
+        self.config: Config = merge_dicts(DEFAULTS, config)
         # The config with uncommitted modifications (any modifications will be
         #  applied to this one)
-        self.config_edited = deepcopy(self.config)
+        self.config_edited: Config = deepcopy(
+            self.config)  # type: ignore[misc]
 
         self.saveConfig = saveConfig
         self.prevView = prevView
@@ -927,7 +928,8 @@ class SDictDelegate(Delegate):
             logger.error(f'createEditor: EditRole data at index {index} is not'
                          f' a len 2 tuple. Received {data} ({type(data)}).')
             data = ('', False)
-        return SDictEntryEditor(*data, parent)
+        # NOTE(plu5, 2025-10-14): alas, mypy broke * in the past year
+        return SDictEntryEditor(data[0], data[1], parent)
 
     def setModelData(self,
                      editor,  # type: QWidget
@@ -1155,7 +1157,7 @@ class RDictDelegate(Delegate):
             logger.error(f'createEditor: EditRole data at index {index} is not'
                          f' a len 2 tuple. Received {data} ({type(data)}).')
             data = ('', [''])
-        return RDictEntryEditor(*data, parent)
+        return RDictEntryEditor(data[0], data[1], parent)
 
     def setModelData(self,
                      editor,  # type: QWidget
@@ -1362,7 +1364,7 @@ class KDictDelegate(Delegate):
             logger.error(f'createEditor: EditRole data at index {index} is not'
                          f' a len 2 tuple. Received {data} ({type(data)}).')
             data = ('', [''])
-        return KDictEntryEditor(*data, parent)
+        return KDictEntryEditor(data[0], data[1], parent)
 
     def setModelData(self,
                      editor,  # type: QWidget


### PR DESCRIPTION
Not worked on the project since February and some things don't work anymore with the new version of mypy (and some probably error on my part). Sad about *

I think it's the first time I introduce into the code an actual type hint that is not in a comment with the `config: Config`. But since 3.6 it apparently does nothing in runtime, and retype has in requirements 3.7+, and probably uses a lot of other things added 3.6-3.7, so I hope it's ok.