### PR TITLE
fix: Autosave erroneous error log

### DIFF
--- a/retype/ui/book_view.py
+++ b/retype/ui/book_view.py
@@ -614,14 +614,15 @@ class BookView(QWidget):
 
     def maybeSave(self):
         # type: (BookView) -> None
-        if self.persistent_pos is None or self.chapter_pos is None or \
-           self.progress is None:
-            logger.error('maybeSave: Unexpected None in positioning '
-                         f'variables. persistent_pos: {self.persistent_pos}, '
-                         f'chapter_pos: {self.chapter_pos}, progress: '
-                         f'{self.progress}')
-            return
         if self.book and self.book.dirty:
+            if self.persistent_pos is None or self.chapter_pos is None or \
+               self.progress is None:
+                logger.error('maybeSave: Unexpected None in positioning '
+                             f'variables. persistent_pos: '
+                             '{self.persistent_pos}, '
+                             f'chapter_pos: {self.chapter_pos}, progress: '
+                             f'{self.progress}')
+                return
             logger.debug(f"Saving progress in '{self.book.title}'")
             data = {'persistent_pos': self.persistent_pos,
                     'chapter_pos': self.chapter_pos,


### PR DESCRIPTION
Minor

When closing retype without opening a book, it would log an error that maybeSave was called without positioning variables set, which is not actually an error in this case and is what is expected to happen. I moved the positioning variables checks to inside the check for self.book so that if a book was not opened in the session nothing happens.