### PR TITLE
fix(Console): Console commands able to mess up text or position

### DIFF
--- a/retype/console/command_service.py
+++ b/retype/console/command_service.py
@@ -121,6 +121,7 @@ class CommandService(object):
         e = text[len(self.prompt):].lower()
         el = e.split(' ')  #
         if text.startswith(self.prompt) and el[0] in self.commands:
+            self._console.clear()  # clear first (#48)
             cmd = self.commands[el[0]]
             if not hasattr(cmd, '__call__'):
                 logger.error(f'Uncallable cmd: {cmd}')
@@ -144,7 +145,6 @@ class CommandService(object):
                 self.command_history.append(text)
 
             self.command_history_pos = None
-            self._console.clear()
 
     def commandHistoryUp(self):
         # type: (CommandService) -> None


### PR DESCRIPTION
Clear the console before executing the command. Text in the console can interfere with commands that affect position or highlighting.

Bugs this resolves:

* `gotoCursorPosition` executed from the console deletes n characters after the cursor, where n is the length of console input.
* `advanceLine` executed repeatedly can cause the visual cursor position and highlighting to get out of sync with actual position: n characters past the actual position, where n is the length of console input.

(#48)