### PR TITLE
ci: Add exclusions and preamble

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,10 @@ on:
         type: string
         required: false
         description: Tag annotation
+      preamble:
+        type: string
+        required: false
+        description: Markdown to prepend to changelog
       prerelease:
         type: boolean
         required: false
@@ -262,3 +266,5 @@ jobs:
           tag_annotation: ${{ needs.data.outputs.annotation }}
           prerelease: ${{ needs.data.outputs.prerelease }}
           files: ./dist/*
+          excluded_types: chore docs ci style
+          preamble: ${{ inputs.preamble }}


### PR DESCRIPTION
There are new parameters in [the releases action](https://github.com/plu5/automatic-releases-with-sha-action) that enable excluding Conventional Commits types from the changelog and adding a markdown preamble. I excluded chore, docs, ci, and style (the latter because the action section title "Styles" is misleading, so avoid it.) and added a workflow dispatch parameter for preamble.