### PR TITLE
ci: macos-13 → macos-14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,10 +82,10 @@ jobs:
           arr=()
           if [ -n "${{ inputs.build_linux }}" ]; then
             [ ${{ inputs.build_linux }} = 'true' ] && arr+=('ubuntu-latest')
-            [ ${{ inputs.build_macos }} = 'true' ] && arr+=('macos-13')
+            [ ${{ inputs.build_macos }} = 'true' ] && arr+=('macos-14')
             [ ${{ inputs.build_windows }} = 'true' ] && arr+=('windows-latest')
           else
-            arr=('ubuntu-latest' 'macos-13' 'windows-latest')
+            arr=('ubuntu-latest' 'macos-14' 'windows-latest')
           fi
           s=$(printf ",\"%s\"" "${arr[@]}")
           echo os=[${s:1}] >> $GITHUB_OUTPUT
@@ -102,7 +102,7 @@ jobs:
         run: |
           output="name=failed"
           [ ${{ matrix.os }} = 'ubuntu-latest' ] && output="name=linux\nartifact=./dist/retype-hacky" 
-          [ ${{ matrix.os }} = 'macos-13' ] && output="name=macos-x86\nartifact=./retype.dmg"
+          [ ${{ matrix.os }} = 'macos-14' ] && output="name=macos-x86\nartifact=./retype.dmg"
           [ ${{ matrix.os }} = 'windows-latest' ] && output="name=windows\nartifact=./dist/retype-hacky"
           echo -e $output >> $GITHUB_OUTPUT
         shell: bash
@@ -152,7 +152,7 @@ jobs:
             venv/bin/python setup.py b -k hacky
 
       - name: 1M. Setup Python ${{ env.PYTHON_VERSION }}
-        if: matrix.os == 'macos-13'
+        if: matrix.os == 'macos-14'
         uses: plu5/macos-setup-python-action@main
         with:
           version: ${{ env.PYTHON_VERSION }}
@@ -164,7 +164,7 @@ jobs:
            python-version: ${{ env.PYTHON_VERSION }}
 
       - name: 2MW. Generate Python venv cache
-        if: matrix.os == 'macos-13' || matrix.os == 'windows-latest'
+        if: matrix.os == 'macos-14' || matrix.os == 'windows-latest'
         id: python_venv_cache
         uses: actions/cache@v3
         with:
@@ -172,7 +172,7 @@ jobs:
           key: venv-${{ env.PYTHON_VERSION }}-${{ hashFiles('requirements.txt') }}-${{ matrix.os }}
 
       - name: 3M. Install dependencies unless cached
-        if: matrix.os == 'macos-13' && steps.python_venv_cache.outputs.cache-hit != 'true'
+        if: matrix.os == 'macos-14' && steps.python_venv_cache.outputs.cache-hit != 'true'
         run: |
           if [ -d "venv" ]; then rm -rf venv; fi
           python3 -m venv venv
@@ -197,11 +197,11 @@ jobs:
           args: 'apply venv/lib/site-packages'
 
       - name: 4M. Run retype setup script
-        if: matrix.os == 'macos-13'
+        if: matrix.os == 'macos-14'
         run: venv/bin/python3 setup.py b -k bundle
 
       - name: 5M. Make dmg
-        if: matrix.os == 'macos-13'
+        if: matrix.os == 'macos-14'
         run: |
           npm install -g appdmg
           appdmg setup/appdmg-config.json retype.dmg


### PR DESCRIPTION
No runners for macos-13 anymore, it gets stuck waiting.

The support for macos-14 won't last much longer either (November), then the next version on, then eventually I think we will no longer be able to make macos builds with GitHub Actions.