### PR TITLE
ci(macos): PyQt5 5.13.0 → 5.14.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ on:
 env:
   VERSION_FILE: 'retype/__init__.py'
   PYTHON_VERSION: 3.7.9
-  MACOSX_DEPLOYMENT_TARGET: 10.9
+  MACOSX_DEPLOYMENT_TARGET: 10.13
 
 jobs:
   data:
@@ -177,7 +177,10 @@ jobs:
           if [ -d "venv" ]; then rm -rf venv; fi
           python3 -m venv venv
           PYINSTALLER_COMPILE_BOOTLOADER=1 venv/bin/python3 -m pip install pyinstaller setuptools
-          venv/bin/python3 -m pip install PyQt5==5.13.0 lxml==4.6.3 # Compatible down to macOS 10.9
+          venv/bin/python3 -m pip install PyQt5==5.14.2 lxml==4.6.3 # Compatible down to macOS 10.13
+          # ^ Explanation:
+          # (1) lxml 4.6.3 supports down to 10.9, 4.6.4 is 10.14+.
+          # (2) PyQt5 5.14+ on macos-14, which supports down to 10.13.
           venv/bin/python3 -m pip install -r requirements.txt
 
       - name: 3W. Install dependencies unless cached


### PR DESCRIPTION
Supports down to macOS 10.13 instead of 10.12.

Even though I had deployment target as 10.9, Qt 5.13 only supported down to 10.12.

This is a consequence to the macOS runner changing to macos-14 in #52, that runner can't install PyQt5 5.13.