### PR TITLE
ci: Change prerelease input default to false

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ on:
       prerelease:
         type: boolean
         required: false
-        default: true
+        default: false
         description: If releasing, whether release should be marked prerelease
       build_linux:
         type: boolean


### PR DESCRIPTION
I don't want to have to modify the release after the fact to uncheck prerelease if I forget to change it to false