### PR TITLE
ci(macOS): Use python3.7 instead of python3 when setting up venv

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -175,7 +175,7 @@ jobs:
         if: matrix.os == 'macos-14' && steps.python_venv_cache.outputs.cache-hit != 'true'
         run: |
           if [ -d "venv" ]; then rm -rf venv; fi
-          python3 -m venv venv
+          python3.7 -m venv venv
           PYINSTALLER_COMPILE_BOOTLOADER=1 venv/bin/python3 -m pip install pyinstaller setuptools
           venv/bin/python3 -m pip install PyQt5==5.14.2 lxml==4.6.3 # Compatible down to macOS 10.13
           # ^ Explanation:


### PR DESCRIPTION
Otherwise it fails because macos-14 has python3.14 installed by default and it uses that one instead of the one I set up