### PR TITLE
feat: Keymap

### DIFF
--- a/retype/controllers/menu_controller.py
+++ b/retype/controllers/menu_controller.py
@@ -1,3 +1,5 @@
+import logging
+import traceback
 from qt import QAction, QObject
 
 from typing import TYPE_CHECKING
@@ -5,8 +7,20 @@ from typing import TYPE_CHECKING
 from retype.constants import (
     RETYPE_ISSUE_TRACKER_URL, RETYPE_DOCUMENTATION_URL, iswindows)
 from retype.resource_handler import getIcon
+from retype.services.keymap import keymap, K, Keymap
+
+logger = logging.getLogger(__name__)
 
 
+@keymap('Menu.quit', K(['Alt+F4']))
+@keymap('Menu.setViewByEnum', K([], {'1': ['Ctrl+1'], '2': ['Ctrl+2']}))
+@keymap('Menu.showCustomisationDialog', K(['Ctrl+O']))
+@keymap('Menu.toggleConsoleWindow', K())
+@keymap('Menu.showTypespeed', K())
+@keymap('Menu.showSteno', K())
+@keymap('Menu.about', K())
+@keymap('Menu.documentation', K())
+@keymap('Menu.reportIssue', K())
 class MenuController(QObject):
     def __init__(self, main_controller, menu):
         # type: (MenuController, MainController, QMenuBar) -> None
@@ -17,21 +31,85 @@ class MenuController(QObject):
 
     def _initMenuBar(self):
         # type: (MenuController) -> None
-        self._fileMenu()
-        self._viewMenu()
-        self._gamesMenu()
-        self._optionsMenu()
-        self._helpMenu()
+        fileMenu = self._menu.addMenu('&File')
+        viewMenu = self._menu.addMenu('&View')
+        gamesMenu = self._menu.addMenu('&Games')
+        optionsMenu = self._menu.addMenu('&Options')
+        helpMenu = self._menu.addMenu('&Help')
+
+        self.actions = {
+            'Menu.quit': {
+                'menu': fileMenu, 'name': '&Quit',
+                'func': self.controller.quit, 'icon': 'door',
+            },
+            'Menu.setViewByEnum:1': {
+                'menu': viewMenu, 'name': '&Shelf View',
+                'func': lambda: self.controller.setViewByEnum(1),
+                'icon': 'shelf_view',
+            },
+            'Menu.setViewByEnum:2': {
+                'menu': viewMenu, 'name': '&Book View',
+                'func': lambda: self.controller.setViewByEnum(2),
+                'icon': 'open_book',
+            },
+            'Menu.toggleConsoleWindow': {
+                'menu': viewMenu, 'name': 'Toggle System &Console',
+                'func': lambda: self.controller.toggleConsoleWindow(),
+                'icon': 'console', 'condition': iswindows,
+                'before': viewMenu.addSeparator,
+            },
+            'Menu.showTypespeed': {
+                'menu': gamesMenu, 'name': '&Typespeed',
+                'func': self.controller.showTypespeed, 'icon': 'typespeed',
+            },
+            'Menu.showSteno': {
+                'menu': gamesMenu, 'name': '&Learn Stenography',
+                'func': self.controller.showSteno, 'icon': 'steno',
+            },
+            'Menu.showCustomisationDialog': {
+                'menu': optionsMenu, 'name': '&Customise retype',
+                'func': self.controller.showCustomisationDialog,
+                'icon': 'customise',
+            },
+            'Menu.about': {
+                'menu': helpMenu, 'name': "&About",
+                'func': self.controller.showAboutDialog, 'icon': 'about',
+            },
+            'Menu.documentation': {
+                'menu': helpMenu, 'name': "&Documentation (opens in browser)",
+                'func': lambda: self.controller.openUrl(
+                    RETYPE_DOCUMENTATION_URL),
+                'icon': 'documentation',
+            },
+            'Menu.reportIssue': {
+                'menu': helpMenu, 'name': '&Report issue (opens in browser)',
+                'func': lambda: self.controller.openUrl(
+                    RETYPE_ISSUE_TRACKER_URL),
+                'icon': 'issue',
+            },
+        }  # type: dict[str, ActionInfo]
+
+        for name, info in self.actions.items():
+            n = name.split(':')
+            selector_name = n[0]
+            argstr = n[1] if len(n) > 1 else ''
+            info['shortcuts'] = Keymap.s(selector_name).s(argstr)
+            if info.pop('condition', True):
+                before = info.pop('before', None)
+                if before:
+                    before()
+                action = self._addAction(**info)
+            info['action'] = action
 
     def _makeAction(self,  # type: MenuController
                     name,  # type: str
-                    connect_to,  # type: Callable[[], None]
+                    func,  # type: Callable[[], None]
                     shortcuts=None,  # type: list[str] | None
                     icon_name=None  # type: str | None
                     ):
         # type: (...) -> QAction
         action = QAction(name, self)
-        action.triggered.connect(connect_to)
+        action.triggered.connect(func)
         if shortcuts:
             action.setShortcuts(shortcuts)
         if icon_name:
@@ -40,68 +118,40 @@ class MenuController(QObject):
 
     def _addAction(self,  # type: MenuController
                    menu,  # type: QMenu
-                   action_name,  # type: str
-                   connect_to,  # type: Callable[[], None]
+                   name,  # type: str
+                   func,  # type: Callable[[], None]
                    shortcuts=None,  # type: list[str] | None
-                   icon_name=None  # type: str | None
+                   icon=None  # type: str | None
                    ):
         # type: (...) -> None
-        action = self._makeAction(action_name, connect_to, shortcuts,
-                                  icon_name)
+        action = self._makeAction(name, func, shortcuts, icon)
         menu.addAction(action)
 
-    def _fileMenu(self):
+    def keymapUpdate(self):
         # type: (MenuController) -> None
-        fileMenu = self._menu.addMenu('&File')
-        self._addAction(fileMenu, '&Quit', self.controller.quit,
-                        ['Alt+F4'], 'door')
-
-    def _viewMenu(self):
-        # type: (MenuController) -> None
-        viewMenu = self._menu.addMenu('&View')
-        self._addAction(viewMenu, '&Shelf View',
-                        lambda: self.controller.setViewByEnum(1), ['Ctrl+1'],
-                        'shelf_view')
-        self._addAction(viewMenu, '&Book View',
-                        lambda: self.controller.setViewByEnum(2), ['Ctrl+2'],
-                        'open_book')
-
-        if iswindows:
-            viewMenu.addSeparator()
-            self._addAction(viewMenu, 'Toggle System &Console',
-                            lambda: self.controller.toggleConsoleWindow(),
-                            icon_name='console')
-
-    def _gamesMenu(self):
-        # type: (MenuController) -> None
-        gamesMenu = self._menu.addMenu('&Games')
-        self._addAction(gamesMenu, '&Typespeed', self.controller.showTypespeed,
-                        icon_name='typespeed')
-        self._addAction(gamesMenu, '&Learn Stenography',
-                        self.controller.showSteno, icon_name='steno')
-
-    def _optionsMenu(self):
-        # type: (MenuController) -> None
-        optionsMenu = self._menu.addMenu('&Options')
-        self._addAction(optionsMenu, '&Customise retype',
-                        self.controller.showCustomisationDialog, ['Ctrl+O'],
-                        'customise')
-
-    def _helpMenu(self):
-        # type: (MenuController) -> None
-        helpMenu = self._menu.addMenu('&Help')
-        self._addAction(helpMenu, "&About", self.controller.showAboutDialog,
-                        icon_name='about')
-        self._addAction(helpMenu, "&Documentation (opens in browser)", lambda:
-                        self.controller.openUrl(RETYPE_DOCUMENTATION_URL),
-                        icon_name='documentation')
-        self._addAction(helpMenu,
-                        '&Report issue (opens in browser)', lambda:
-                        self.controller.openUrl(RETYPE_ISSUE_TRACKER_URL),
-                        icon_name='issue')
+        if not hasattr(self, 'actions'):
+            logger.warning("keymapUpdate called with no actions set")
+            return
+        for name, d in self.actions.items():
+            n = name.split(':')
+            selector_name = n[0]
+            argstr = n[1] if len(n) > 1 else ''
+            try:
+                s = Keymap.s(selector_name).s(argstr)
+                d['shortcuts'] = s
+                d['action'].setShortcuts(s)
+            except KeyError:
+                logger.error(f"Updating k '{name}' failed with KeyError. "
+                             f"{traceback.format_exc()}")
 
 
 if TYPE_CHECKING:
-    from qt import QMenu, QMenuBar  # noqa: F401
+    from qt import QMenu, QMenuBar, QKeySequence  # noqa: F401
     from retype.controllers import MainController  # noqa: F401
-    from typing import Callable  # noqa: F401
+    from typing import Callable, TypedDict  # noqa: F401
+    ActionInfo = TypedDict(
+        'ActionInfo',
+        {'menu': QMenu, 'name': str, 'func': Callable[[], None],
+         'tooltip': str, 'shortcuts': list[str], 'icon': str,
+         'action': QAction, 'condition': bool, 'before': Callable[[], None]},
+        total=False)

--- a/retype/controllers/menu_controller.py
+++ b/retype/controllers/menu_controller.py
@@ -100,7 +100,7 @@ class MenuController(QObject):
                 if before:
                     before()
                 action = self._addAction(**info)
-            info['action'] = action
+                info['action'] = action
 
     def _makeAction(self,  # type: MenuController
                     name,  # type: str

--- a/retype/controllers/menu_controller.py
+++ b/retype/controllers/menu_controller.py
@@ -28,6 +28,7 @@ class MenuController(QObject):
         self.controller = main_controller
         self._menu = menu
         self._initMenuBar()
+        Keymap.notifier.changed.connect(self.keymapUpdate)
 
     def _initMenuBar(self):
         # type: (MenuController) -> None
@@ -123,9 +124,10 @@ class MenuController(QObject):
                    shortcuts=None,  # type: list[str] | None
                    icon=None  # type: str | None
                    ):
-        # type: (...) -> None
+        # type: (...) -> QAction
         action = self._makeAction(name, func, shortcuts, icon)
         menu.addAction(action)
+        return action
 
     def keymapUpdate(self):
         # type: (MenuController) -> None
@@ -139,9 +141,14 @@ class MenuController(QObject):
             try:
                 s = Keymap.s(selector_name).s(argstr)
                 d['shortcuts'] = s
-                d['action'].setShortcuts(s)
-            except KeyError:
-                logger.error(f"Updating k '{name}' failed with KeyError. "
+                # Action could be None for OS-specific actions
+                action = d.get('action')
+                if action:
+                    action.setShortcuts(s)
+                else:
+                    logger.debug(f"Skip updating non-existing action {name}")
+            except KeyError, AttributeError:
+                logger.error(f"Updating k '{name}' failed. "
                              f"{traceback.format_exc()}")
 
 

--- a/retype/controllers/menu_controller.py
+++ b/retype/controllers/menu_controller.py
@@ -147,7 +147,7 @@ class MenuController(QObject):
                     action.setShortcuts(s)
                 else:
                     logger.debug(f"Skip updating non-existing action {name}")
-            except KeyError, AttributeError:
+            except (KeyError, AttributeError):
                 logger.error(f"Updating k '{name}' failed. "
                              f"{traceback.format_exc()}")
 

--- a/retype/extras/widgets.py
+++ b/retype/extras/widgets.py
@@ -176,9 +176,13 @@ class EscapableKeySequenceEdit(QKeySequenceEdit):
 
     def keyPressEvent(self, e):
         # type: (EscapableKeySequenceEdit, QKeyEvent) -> None
-        if e.key() == Qt.Key_Escape:
-            self.clearFocus()
-            return
+        if not e.modifiers():
+            if e.key() == Qt.Key_Escape:
+                self.clearFocus()
+                return
+            elif e.key() in [Qt.Key_Backspace, Qt.Key_Delete]:
+                self.clear()
+                return
         QKeySequenceEdit.keyPressEvent(self, e)
 
 

--- a/retype/extras/widgets.py
+++ b/retype/extras/widgets.py
@@ -1,6 +1,6 @@
 from qt import (QTabWidget, QStyle, QStyleOptionTabWidgetFrame, QStackedWidget,
                 QWidget, QScrollArea, QLabel, QSize, QHBoxLayout,
-                QTextDocument, QTextBrowser)
+                QTextDocument, QTextBrowser, QKeySequenceEdit, Qt)
 
 from typing import TYPE_CHECKING
 
@@ -169,5 +169,18 @@ class ReadOnlyTextWidget(QWidget):
         lyt.setContentsMargins(0, 0, 0, 0)
 
 
+class EscapableKeySequenceEdit(QKeySequenceEdit):
+    def __init__(self, parent=None):
+        # type: (EscapableKeySequenceEdit, QWidget | None) -> None
+        QKeySequenceEdit.__init__(self, parent)
+
+    def keyPressEvent(self, e):
+        # type: (EscapableKeySequenceEdit, QKeyEvent) -> None
+        if e.key() == Qt.Key_Escape:
+            self.clearFocus()
+            return
+        QKeySequenceEdit.keyPressEvent(self, e)
+
+
 if TYPE_CHECKING:
-    from qt import QResizeEvent, QIcon  # noqa: F401
+    from qt import QResizeEvent, QKeyEvent, QIcon  # noqa: F401

--- a/retype/services/keymap.py
+++ b/retype/services/keymap.py
@@ -1,0 +1,134 @@
+import os
+import json
+import logging
+import traceback
+from qt import QObject, pyqtSignal
+
+from typing import TYPE_CHECKING
+
+logger = logging.getLogger(__name__)
+
+
+class K(QObject):
+    changed = pyqtSignal()
+
+    def __init__(self,  # type: K
+                 shortcuts_no_argstr=None,  # type: list[str] | None
+                 shortcuts_per_argstr=None  # type: dict[str, list[str]] | None
+                 ):
+        # type: (...) -> None
+        QObject.__init__(self)
+        self.name = ''
+        self.entries_map = {'': shortcuts_no_argstr or []}
+        if shortcuts_per_argstr is not None:
+            self.entries_map = {**self.entries_map, **shortcuts_per_argstr}
+
+    def entries(self):
+        # type: (K) -> dict_items
+        return self.entries_map.items()
+
+    def s(self, argstr=''):
+        # type: (K) -> list[str]
+        """Get shortcuts list for an entry"""
+        res = self.entries_map.get(argstr, [])
+        assert type(res) is list
+        return res
+
+    def set_(self, entries_map):
+        # type: (dict[str, list[str]]) -> bool
+        if entries_map != self.entries_map:
+            self.entries_map = entries_map
+            self.changed.emit()
+            return True
+        return False
+
+
+class Keymap:
+    selectors = {}  # type: dict[str, K]
+    notifier = K()
+    keymaps = {}  # type: dict[str, KeymapData]
+
+    @staticmethod
+    def s(selector_name):
+        # type: (str) -> K
+        ret = Keymap.selectors.get(selector_name)
+        if ret is None:
+            logger.warning(f'Invalid keymap selector name {selector_name}')
+            ret = K()
+        return ret
+
+    @staticmethod
+    def getValuesDict():
+        # type: () -> ValuesDict
+        values = {}  # type: ValuesDict
+        for name, k in Keymap.selectors.items():
+            values[name] = {**k.entries_map}
+        return values
+
+    @staticmethod
+    def set_(values):
+        # type: (ValuesDict) -> None
+        changed = False
+        for name, d in values.items():
+            try:
+                changed_ = Keymap.selectors[name].set_(d)
+                changed = changed if changed else changed_
+            except KeyError:
+                logger.error(
+                    f'Keymap.set_: Invalid keymap selector name {name}')
+        if changed:
+            Keymap.notifier.changed.emit()
+
+
+def getKeymapValues(name, path):
+    # type: (str, str) -> ValuesDict
+    values = {n: {'': []} for n in Keymap.selectors.keys()}  # fallback
+    if os.path.exists(path):
+        try:
+            with open(path, 'r') as f:
+                values.update(json.load(f))
+        except OSError:
+            logger.error(f'Failed to open keymap file {name} in {path}.'
+                         f'{traceback.format_exc()}')
+        except json.decoder.JSONDecodeError:
+            logger.error(f'Failed to parse keymap file {name} in {path}.'
+                         f'{traceback.format_exc()}')
+    else:
+        logger.warning(f'Keymap {name} in path {path} not found.')
+    return values
+
+
+def populateKeymaps(app_path, user_path):
+    # type: (str, str) -> None
+    Keymap.keymaps = {}
+    paths = [app_path, user_path] if app_path != user_path else [app_path]
+    for path in paths:
+        for root, _, files in os.walk(path):
+            for f in files:
+                if f.lower().endswith('.json'):
+                    p = os.path.join(root, f)
+                    name = os.path.splitext(f.lower())[0]
+                    if name in Keymap.keymaps and path == user_path:
+                        name += ' (user dir)'
+                    values = getKeymapValues(name, p)
+                    Keymap.keymaps[name] = {'path': p, 'values': values}
+            break  # do not recurse
+
+
+def keymap(selector, k):
+    # type: (str, K) -> Callable[[type[T]], type[T]]
+    def decorator(cls):
+        # type: (type[T]) -> type[T]
+        k.name = selector
+        Keymap.selectors[selector] = k
+        return cls
+    return decorator
+
+
+if TYPE_CHECKING:
+    from typing import Callable, TypeVar, TypedDict  # noqa: F401
+    T = TypeVar('T')
+    ValuesDict = dict[str, dict[str, list[str]]]
+    KeymapData = TypedDict(
+        'KeymapData',
+        {'path': str, 'values': ValuesDict})

--- a/retype/ui/book_view.py
+++ b/retype/ui/book_view.py
@@ -217,6 +217,8 @@ class BookView(QWidget):
         self.c_mistake.changed.connect(self.themeUpdate)
         self.themeUpdate()
 
+        Keymap.notifier.changed.connect(self.keymapUpdate)
+
     def _loadTheme(self):
         # type: (BookView) -> tuple[C, ...]
         return (Theme.get('BookView.Highlighting.Highlight'),

--- a/retype/ui/book_view.py
+++ b/retype/ui/book_view.py
@@ -1,4 +1,5 @@
 import logging
+import traceback
 from qt import (QWidget, QVBoxLayout, QTextBrowser, QTextDocument, QUrl,
                 QTextCursor, QTextCharFormat, QPainter, QPixmap,
                 QToolBar, QFont, QKeySequence, Qt, QApplication, pyqtSignal,
@@ -12,6 +13,7 @@ from retype.services import Autosave
 from retype.stats import StatsDock
 from retype.resource_handler import getIcon
 from retype.services.theme import theme, C, Theme
+from retype.services.keymap import keymap, K, Keymap
 from retype.constants import default_font_family, default_font_size
 
 logger = logging.getLogger(__name__)
@@ -155,6 +157,13 @@ class BookDisplay(QTextBrowser):
         QTextBrowser.wheelEvent(self, e)
 
 
+@keymap('BookView.gotoCursorPosition', K())
+@keymap('BookView.switchToShelves', K())
+@keymap('BookView.previousChapter', K())
+@keymap('BookView.nextChapter', K())
+@keymap('BookView.skipLine', K())
+@keymap('BookView.zoomIn', K([QKeySequence.StandardKey.ZoomIn]))
+@keymap('BookView.zoomOut', K([QKeySequence.StandardKey.ZoomOut]))
 @theme('BookView.Highlighting.Highlight', C(bg='#30ffff00'))
 @theme('BookView.Highlighting.Mistake', C(fg='white', bg='red'))
 class BookView(QWidget):
@@ -218,6 +227,23 @@ class BookView(QWidget):
         self.mistake_format.setForeground(self.c_mistake.fg())
         self.mistake_format.setBackground(self.c_mistake.bg())
 
+    def keymapUpdate(self):
+        # type: (BookView) -> None
+        if not hasattr(self, 'actions'):
+            logger.warning("keymapUpdate called with no actions set")
+            return
+        for name, d in self.actions.items():
+            n = name.split(':')
+            selector_name = n[0]
+            argstr = n[1] if len(n) > 1 else ''
+            try:
+                s = Keymap.s(selector_name).s(argstr)
+                d['shortcuts'] = s
+                d['action'].setShortcuts(s)
+            except KeyError:
+                logger.error(f"Updating k '{name}' failed with KeyError. "
+                             f"{traceback.format_exc()}")
+
     def _initUI(self):
         # type: (BookView) -> None
         self.display.anchorClicked.connect(self.anchorClicked)
@@ -252,13 +278,13 @@ class BookView(QWidget):
         self.toolbar = QToolBar(self)
         self.toolbar.setIconSize(QSize(16, 16))
 
-        actions = {
-            'back':
+        self.actions = {
+            'BookView.switchToShelves':
             {
                 'name': 'Back to shelves',
-                'func': self.switchToShelves
+                'func': self.switchToShelves,
             },
-            'pos':
+            'BookView.gotoCursorPosition':
             {
                 'name': 'Cursor position',
                 'func': self.gotoCursorPosition,
@@ -266,7 +292,7 @@ class BookView(QWidget):
  cursor to your current position',
                 'icon': 'cursor'
             },
-            'pchap':
+            'BookView.previousChapter':
             {
                 'name': 'Previous chapter',
                 'func': self.previousChapterAction,
@@ -274,7 +300,7 @@ class BookView(QWidget):
  cursor with you as well',
                 'icon': 'arrow-left'
             },
-            'nchap':
+            'BookView.nextChapter':
             {
                 'name': 'Next chapter',
                 'func': self.nextChapterAction,
@@ -282,25 +308,23 @@ class BookView(QWidget):
  with you as well',
                 'icon': 'arrow-right'
             },
-            'skip':
+            'BookView.skipLine':
             {
                 'name': 'Skip line',
                 'func': self.advanceLine,
                 'tooltip': 'Move cursor to next line',
                 'icon': 'skip'
             },
-            'zoomin':
+            'BookView.zoomIn':
             {
                 'name': 'Increase font size',
                 'func': self.display.zoomIn,
-                'shortcut': QKeySequence(QKeySequence.StandardKey.ZoomIn),
                 'icon': 't-up'
             },
-            'zoomout':
+            'BookView.zoomOut':
             {
                 'name': 'Decrease font size',
                 'func': self.display.zoomOut,
-                'shortcut': QKeySequence(QKeySequence.StandardKey.ZoomOut),
                 'icon': 't-down'
             }
         }  # type: dict[str, ActionInfo]
@@ -308,7 +332,7 @@ class BookView(QWidget):
         def addAction(name,  # type: str
                       func,  # type: Callable[[], None]
                       tooltip=None,  # type: str | None
-                      shortcut=None,  # type: Shortcut | None
+                      shortcuts=None,  # type: list[Shortcut] | None
                       icon=None,  # type: str | None
                       action=None  # type: QAction | None  # unused
                       ):
@@ -316,21 +340,26 @@ class BookView(QWidget):
             a = self.toolbar.addAction(name, func)
             if tooltip:
                 a.setToolTip(tooltip)
-            if shortcut:
-                a.setShortcut(shortcut)
+            if shortcuts:
+                a.setShortcuts(shortcuts)
             if icon:
                 a.setIcon(getIcon(icon))
             return a
 
-        for k, v in actions.items():
-            action = addAction(**v)
-            actions[k]['action'] = action
+        for name, info in self.actions.items():
+            n = name.split(':')
+            selector_name = n[0]
+            argstr = n[1] if len(n) > 1 else ''
+            info['shortcuts'] = Keymap.s(selector_name).s(argstr)
+            action = addAction(**info)
+            info['action'] = action
 
-        self.pchap_action = actions['pchap']['action']
-        self.nchap_action = actions['nchap']['action']
-        self.skip_action = actions['skip']['action']
+        self.pchap_action = self.actions['BookView.previousChapter']['action']
+        self.nchap_action = self.actions['BookView.nextChapter']['action']
+        self.skip_action = self.actions['BookView.skipLine']['action']
 
-        self.toolbar.insertSeparator(actions['pos']['action'])
+        self.toolbar.insertSeparator(
+            self.actions['BookView.gotoCursorPosition']['action'])
 
     def _initModeline(self):
         # type: (BookView) -> None
@@ -724,5 +753,5 @@ if TYPE_CHECKING:
     ActionInfo = TypedDict(
         'ActionInfo',
         {'name': str, 'func': Callable[[], None], 'tooltip': str,
-         'shortcut': QKeySequence, 'icon': str, 'action': QAction},
+         'shortcuts': list[str], 'icon': str, 'action': QAction},
         total=False)

--- a/retype/ui/customisation_dialog.py
+++ b/retype/ui/customisation_dialog.py
@@ -20,7 +20,7 @@ from retype.extras.dict import merge_dicts, update
 from retype.constants import default_config, iswindows, default_steno_kdict
 from retype.services.theme import (Theme, populateThemes, valuesFromQss, theme,
                                    C)
-from retype.services.keymap import Keymap, populateKeymaps
+from retype.services.keymap import Keymap, populateKeymaps, getKeymapValues
 from retype.extras.qss import serialiseValuesDict
 from retype.resource_handler import getStylePath
 from retype.extras.widgets import (ScrollTabWidget, AdjustedStackedWidget,
@@ -34,6 +34,7 @@ logger = logging.getLogger(__name__)
 
 DEFAULTS = default_config
 THEME_MODIFICATIONS_FILENAME = '__current__.qss'
+KEYMAP_MODIFICATIONS_FILENAME = '__current_keymap__.json'
 NPXSPINBOX_MINIMUM_VALUE = -10001
 
 
@@ -268,12 +269,14 @@ class CustomisationDialog(QDialog):
 
         user_dir = self.getUserDir()
         populateKeymaps(getStylePath(), getStylePath(user_dir))
+        prefix_to_exclude = KEYMAP_MODIFICATIONS_FILENAME.rsplit('.', 1)[0]
         for km in Keymap.keymaps:
-            keymaps.addItem(km)
+            if not km.startswith(prefix_to_exclude):
+                keymaps.addItem(km)
         keymaps.model().sort(0)
         keymaps.setCurrentIndex(0)
 
-        self.keymap = KeymapWidget()
+        self.keymap = KeymapWidget(user_dir)
         lyt.addRow(self.keymap)
 
         apply_btn.clicked.connect(
@@ -449,7 +452,7 @@ class CustomisationDialog(QDialog):
         self.theme.saveCurrent(getStylePath(self.getUserDir()))
 
         # Save keymap
-        self.keymap.saveCurrent()
+        self.keymap.saveCurrent(getStylePath(self.getUserDir()))
 
         self.revert_btn.setEnabled(False)
 
@@ -2071,12 +2074,16 @@ class ThemeWidget(QWidget):
 class KeymapSelectorWidget(QWidget):
     changed = pyqtSignal()
 
-    def __init__(self, k, parent=None):
-        # type: (KeymapSelectorWidget, K, QWidget | None) -> None
+    def __init__(self,  # type: KeymapSelectorWidget
+                 selector_name,  # type: str
+                 entries_map,  # type: dict[str, list[str]]
+                 parent=None  # type: QWidget | None
+                 ):
+        # type: (...) -> None
         QWidget.__init__(self, parent)
         self.lyt = QFormLayout(self)
-        self.lyt.addRow(QLabel(f'<b>{k.name}</b>'))
-        for argstr, shortcuts in k.entries():
+        self.lyt.addRow(QLabel(f'<b>{selector_name}</b>'))
+        for argstr, shortcuts in entries_map.items():
             if argstr == '':
                 editor = EscapableKeySequenceEdit()
                 if len(shortcuts):
@@ -2178,9 +2185,11 @@ class KeymapCategoryWidget(QWidget):
 
 
 class KeymapWidget(QWidget):
-    def __init__(self, parent=None):
-        # type: (KeymapWidget, QWidget | None) -> None
+    def __init__(self, user_dir, parent=None):
+        # type: (KeymapWidget, str, QWidget | None) -> None
         QWidget.__init__(self, parent)
+        self.default_values = Keymap.getValuesDict()
+        self.values = self._loadValues(getStylePath(user_dir))
         self.cat_widgets = {}  # type: dict[str, KeymapCategoryWidget]
         self.selector_widgets = {}  # type: dict[str, KeymapSelectorWidget]
         self.lyt = QVBoxLayout(self)
@@ -2189,10 +2198,24 @@ class KeymapWidget(QWidget):
         self.lyt.addWidget(self.tabw)
         self._populateWidgets()
 
+    def _loadValues(self, path):
+        # type: (KeymapWidget, str) -> dict[str, dict[str, list[str]]]
+        values = {}  # dict[str, dict[str, list[str]]]
+        file_path = os.path.join(path, KEYMAP_MODIFICATIONS_FILENAME)
+        if os.path.exists(file_path):
+            values = getKeymapValues(KEYMAP_MODIFICATIONS_FILENAME, file_path)
+            # Update shortcuts in application
+            Keymap.set_(values)
+        else:
+            logger.debug(f'Current keymap {file_path} not found. This is\
+ normal on first launch or if it has not been saved yet. Falling back to\
+ default values.')
+        return values or self.default_values
+
     def _populateWidgets(self):
         # type: (KeymapWidget) -> None
-        for name, k in Keymap.selectors.items():
-            selector_widget = KeymapSelectorWidget(k)
+        for name, entries_map in self.values.items():
+            selector_widget = KeymapSelectorWidget(name, entries_map)
             self.selector_widgets[name] = selector_widget
             cat_name = self.friendlyCatName(name)
             cat = self.cat_widgets.get(cat_name)
@@ -2240,9 +2263,17 @@ class KeymapWidget(QWidget):
             logger.error(f'Failed to save keymap to file {file_path}')
             logger.error(f'{type(e)}: {e}')
 
-    def saveCurrent(self):
+    def saveCurrent(self, path):
         # type: (KeymapWidget) -> None
-        Keymap.set_(self.get())
+        # Get values dict
+        values = self.get()
+        # Serialise
+        res = json.dumps(values, indent=2)
+        # Write to file in path
+        file_path = os.path.join(path, KEYMAP_MODIFICATIONS_FILENAME)
+        self._save(file_path, res)
+        # Update keymap in application
+        Keymap.set_(values)
 
     def exportCurrent(self, user_dir):
         # type: (KeymapWidget, str) -> None

--- a/retype/ui/customisation_dialog.py
+++ b/retype/ui/customisation_dialog.py
@@ -2231,6 +2231,12 @@ class KeymapSelectorWidget(QWidget):
         self.set_(self.entries_map)
         self.handleChange()
 
+    def commitCurrent(self):
+        # type: (KeymapSelectorWidget) -> None
+        self.entries_map = self.get()
+        self.committed = True
+        self.revertbtn.hide()
+
 
 class KeymapCategoryWidget(QWidget):
     def __init__(self, parent=None):
@@ -2251,14 +2257,13 @@ class KeymapWidget(QWidget):
         QWidget.__init__(self, parent)
         self.committed = True
         self.default_values = Keymap.getValuesDict()
-        self.values = self._loadValues(getStylePath(user_dir))
         self.cat_widgets = {}  # type: dict[str, KeymapCategoryWidget]
         self.selector_widgets = {}  # type: dict[str, KeymapSelectorWidget]
         self.lyt = QVBoxLayout(self)
         self.lyt.setContentsMargins(0, 0, 0, 0)
         self.tabw = ScrollTabWidget()
         self.lyt.addWidget(self.tabw)
-        self._populateWidgets()
+        self._populateWidgets(self._loadValues(getStylePath(user_dir)))
 
     def _loadValues(self, path):
         # type: (KeymapWidget, str) -> dict[str, dict[str, list[str]]]
@@ -2274,9 +2279,9 @@ class KeymapWidget(QWidget):
  default values.')
         return values or self.default_values
 
-    def _populateWidgets(self):
-        # type: (KeymapWidget) -> None
-        for name, entries_map in self.values.items():
+    def _populateWidgets(self, values):
+        # type: (KeymapWidget, dict[str, dict[str, list[str]]]) -> None
+        for name, entries_map in values.items():
             selector_widget = KeymapSelectorWidget(name, entries_map)
             selector_widget.changed.connect(self._selectorWidgetChanged)
             self.selector_widgets[name] = selector_widget
@@ -2337,6 +2342,10 @@ class KeymapWidget(QWidget):
         self._save(file_path, res)
         # Update keymap in application
         Keymap.set_(values)
+        # Commit changes
+        for name, widget in self.selector_widgets.items():
+            widget.commitCurrent()
+        self.committed = True
 
     def exportCurrent(self, user_dir):
         # type: (KeymapWidget, str) -> None

--- a/retype/ui/customisation_dialog.py
+++ b/retype/ui/customisation_dialog.py
@@ -18,10 +18,12 @@ from retype.extras.dict import merge_dicts, update
 from retype.constants import default_config, iswindows, default_steno_kdict
 from retype.services.theme import (Theme, populateThemes, valuesFromQss, theme,
                                    C)
+from retype.services.keymap import Keymap
 from retype.extras.qss import serialiseValuesDict
 from retype.resource_handler import getStylePath
 from retype.extras.widgets import (ScrollTabWidget, AdjustedStackedWidget,
-                                   WrappedLabel, MinWidget)
+                                   WrappedLabel, MinWidget,
+                                   EscapableKeySequenceEdit)
 from retype.extras.camel import spacecamel
 from retype.services.icon_set import Icons
 from retype.games.steno import VisualStenoKeyboard
@@ -130,6 +132,7 @@ class CustomisationDialog(QDialog):
         catw.add("Filesystem", "Paths", self._pathSettings())
         catw.add("User interface", "Icons", self._iconsSettings())
         catw.add("User interface", "Theme", self._themeSettings())
+        catw.add("User interface", "Keymap", self._keymapSettings())
         catw.add("User interface", "Console", self._consoleSettings())
         catw.add("User interface", "Book View", self._bookviewSettings())
         catw.add("User interface", "Window geometry", self._windowSettings())
@@ -239,6 +242,14 @@ class CustomisationDialog(QDialog):
             lambda: self.theme.exportCurrent(self.getUserDir()))
 
         return pth
+
+    def _keymapSettings(self):
+        # type: (CustomisationDialog) -> QWidget
+        pkm = QWidget()
+        lyt = QFormLayout(pkm)
+        lyt.setContentsMargins(0, 0, 0, 0)
+        lyt.addRow(KeymapWidget())
+        return pkm
 
     def _consoleSettings(self):
         # type: (CustomisationDialog) -> QWidget
@@ -2021,6 +2032,96 @@ class ThemeWidget(QWidget):
         return self.minimumSizeHint()
 
 
+class KeymapSelectorWidget(QWidget):
+    changed = pyqtSignal()
+
+    def __init__(self, k, parent=None):
+        # type: (KeymapSelectorWidget, K, QWidget | None) -> None
+        QWidget.__init__(self, parent)
+        self.lyt = QFormLayout(self)
+        self.lyt.addRow(QLabel(f'<b>{k.name}</b>'))
+        for argstr, shortcuts in k.entries():
+            if argstr == '':
+                editor = EscapableKeySequenceEdit()
+                if len(shortcuts):
+                    editor.setKeySequence(shortcuts[0])
+                    shortcuts = shortcuts[1:]
+                eargstr = QLineEdit()
+                eargstr.setPlaceholderText("No arguments")
+                eargstr.setEnabled(False)
+                self.lyt.addRow(eargstr, editor)
+                self.addbtn = QPushButton("+ Add")
+                self.addbtn.clicked.connect(self.addEntry)
+                self.lyt.addRow("Additional shortcuts:", self.addbtn)
+            for s in shortcuts:
+                self.addEntry(s, argstr)
+
+    def addEntry(self, s="", argstr=""):
+        # type: (KeymapSelectorWidget, str, str) -> None
+        editor = EscapableKeySequenceEdit()
+        if s:
+            editor.setKeySequence(s)
+        w = QWidget()
+        wlyt = QHBoxLayout(w)
+        wlyt.setContentsMargins(0, 0, 0, 0)
+        wlyt.addWidget(editor)
+        rembtn = QPushButton("- Remove")
+        rembtn.clicked.connect(lambda: self.lyt.removeRow(w))
+        wlyt.addWidget(rembtn)
+        eargstr = QLineEdit(argstr)
+        eargstr.setPlaceholderText("Optional arguments")
+        self.lyt.addRow(eargstr, w)
+
+
+class KeymapCategoryWidget(QWidget):
+    def __init__(self, parent=None):
+        # type: (KeymapCategoryWidget, QWidget | None) -> None
+        QWidget.__init__(self, parent)
+        self.lyt = QFormLayout(self)
+
+    def addSelectorWidget(self, widget):
+        # type: (KeymapCategoryWidget, KeymapSelectorWidget) -> None
+        self.lyt.addRow(widget)
+
+
+class KeymapWidget(QWidget):
+    def __init__(self, parent=None):
+        # type: (KeymapWidget, QWidget | None) -> None
+        QWidget.__init__(self, parent)
+        self.cat_widgets = {}  # type: dict[str, KeymapCategoryWidget]
+        self.lyt = QVBoxLayout(self)
+        self.lyt.setContentsMargins(0, 0, 0, 0)
+        self.tabw = ScrollTabWidget()
+        self.lyt.addWidget(self.tabw)
+        self._populateWidgets()
+
+    def _populateWidgets(self):
+        # type: (KeymapWidget) -> None
+        for n, k in Keymap.selectors.items():
+            selector_widget = KeymapSelectorWidget(k)
+            cat_name = self.friendlyCatName(n)
+            cat = self.cat_widgets.get(cat_name)
+            if (cat):
+                cat.addSelectorWidget(selector_widget)
+            else:
+                cat_widget = KeymapCategoryWidget()
+                cat_widget.addSelectorWidget(selector_widget)
+                self.cat_widgets[cat_name] = cat_widget
+                self.tabw.addTab(cat_widget, cat_name)
+
+    def friendlyCatName(self, name):
+        # type: (KeymapWidget, str) -> str
+        return spacecamel(name.split('.')[0])
+
+    def minimumSizeHint(self):
+        # type: (KeymapWidget) -> QSize
+        return QSize(100, 100)
+
+    def sizeHint(self):
+        # type: (KeymapWidget) -> QSize
+        return self.minimumSizeHint()
+
+
 class CategoriesDelegate(QItemDelegate):
     def __init__(self, parent=None):
         # type: (CategoriesDelegate, QWidget | None) -> None
@@ -2036,6 +2137,8 @@ class CategoriesDelegate(QItemDelegate):
         # type: (...) -> None
         newoption = option
         if not option.state & QStyle.StateFlag.State_Enabled:  # Sections
+            # TODO(plu5): fix this for dark themes.
+            # It needs to be lighter in that case.
             painter.fillRect(rect, option.palette.window().color().darker(106))
             painter.setPen(option.palette.window().color().darker(130))
             if rect.top():

--- a/retype/ui/customisation_dialog.py
+++ b/retype/ui/customisation_dialog.py
@@ -2186,7 +2186,8 @@ class KeymapSelectorWidget(QWidget):
         values = {}
         for argstr, s, _, _ in self.widgets():
             if values.get(argstr):
-                values[argstr].append(s)
+                if s:
+                    values[argstr].append(s)
             else:
                 values[argstr] = [s]
         return values

--- a/retype/ui/customisation_dialog.py
+++ b/retype/ui/customisation_dialog.py
@@ -277,6 +277,7 @@ class CustomisationDialog(QDialog):
         keymaps.setCurrentIndex(0)
 
         self.keymap = KeymapWidget(user_dir)
+        self.keymap.changed.connect(self.keymapUpdate)
         lyt.addRow(self.keymap)
 
         apply_btn.clicked.connect(
@@ -414,6 +415,17 @@ class CustomisationDialog(QDialog):
         self.revert_btn.setEnabled(revert)
         self.restore_btn.setEnabled(restore)
 
+    def keymapUpdate(self):
+        # type: (CustomisationDialog) -> None
+        revert = False
+
+        if self.keymap.committed is False:
+            revert = True
+        else:
+            revert = self.config_edited != self.config
+
+        self.revert_btn.setEnabled(revert)
+
     def accept(self):
         # type: (CustomisationDialog) -> None
         # User dir validation
@@ -476,6 +488,7 @@ class CustomisationDialog(QDialog):
         self.setSelectors(self.config_edited)
 
         self.theme.revert()
+        self.keymap.revert()
 
         self.revert_btn.setEnabled(False)
 
@@ -2081,14 +2094,25 @@ class KeymapSelectorWidget(QWidget):
                  ):
         # type: (...) -> None
         QWidget.__init__(self, parent)
+        self.entries_map = entries_map
+        self.initialised = False
+        self.committed = True
         self.lyt = QFormLayout(self)
-        self.lyt.addRow(QLabel(f'<b>{selector_name}</b>'))
+        self.lyt.setContentsMargins(0, 0, 0, 0)
+        self.revertbtn = QToolButton()
+        self.revertbtn.setArrowType(Qt.ArrowType.LeftArrow)
+        self.revertbtn.setFixedSize(16, 13)
+        self.revertbtn.setToolTip("Revert")
+        self.revertbtn.hide()
+        self.revertbtn.clicked.connect(self.revert)
+        self.lyt.addRow(QLabel(f'<b>{selector_name}</b>'), self.revertbtn)
         for argstr, shortcuts in entries_map.items():
             if argstr == '':
                 editor = EscapableKeySequenceEdit()
                 if len(shortcuts):
                     editor.setKeySequence(shortcuts[0])
                     shortcuts = shortcuts[1:]
+                editor.keySequenceChanged.connect(self.handleChange)
                 eargstr = QLineEdit()
                 eargstr.setPlaceholderText("No arguments")
                 eargstr.setEnabled(False)
@@ -2099,21 +2123,31 @@ class KeymapSelectorWidget(QWidget):
             for s in shortcuts:
                 self.addEntry(s, argstr)
 
+        self.initialised = True
+
     def addEntry(self, s="", argstr=""):
         # type: (KeymapSelectorWidget, str, str) -> None
         editor = EscapableKeySequenceEdit()
         if s:
             editor.setKeySequence(s)
+        editor.keySequenceChanged.connect(self.handleChange)
         w = QWidget()
         wlyt = QHBoxLayout(w)
         wlyt.setContentsMargins(0, 0, 0, 0)
         wlyt.addWidget(editor)
         rembtn = QPushButton("- Remove")
-        rembtn.clicked.connect(lambda: self.lyt.removeRow(w))
+        rembtn.clicked.connect(lambda: self.removeEntry(w))
         wlyt.addWidget(rembtn)
         eargstr = QLineEdit(argstr)
         eargstr.setPlaceholderText("Optional arguments")
+        eargstr.textChanged.connect(self.handleChange)
         self.lyt.addRow(eargstr, w)
+
+    def removeEntry(self, widget):
+        # type: (KeymapSelectorWidget, QWidget) -> None
+        """widget: no matter which widget on that row"""
+        self.lyt.removeRow(widget)
+        self.handleChange()
 
     def widgets(self):
         # type: (KeymapSelectorWidget) -> Iterator
@@ -2172,6 +2206,23 @@ class KeymapSelectorWidget(QWidget):
             for shortcut in s:
                 self.addEntry(shortcut, argstr)
 
+    def handleChange(self):
+        # type: (KeymapSelectorWidget) -> None
+        if not self.initialised:
+            return
+        if self.get() == self.entries_map:
+            self.committed = True
+            self.revertbtn.hide()
+        else:
+            self.committed = False
+            self.revertbtn.show()
+        self.changed.emit()
+
+    def revert(self):
+        # type: (KeymapSelectorWidget) -> None
+        self.set_(self.entries_map)
+        self.handleChange()
+
 
 class KeymapCategoryWidget(QWidget):
     def __init__(self, parent=None):
@@ -2185,9 +2236,12 @@ class KeymapCategoryWidget(QWidget):
 
 
 class KeymapWidget(QWidget):
+    changed = pyqtSignal()
+
     def __init__(self, user_dir, parent=None):
         # type: (KeymapWidget, str, QWidget | None) -> None
         QWidget.__init__(self, parent)
+        self.committed = True
         self.default_values = Keymap.getValuesDict()
         self.values = self._loadValues(getStylePath(user_dir))
         self.cat_widgets = {}  # type: dict[str, KeymapCategoryWidget]
@@ -2216,6 +2270,7 @@ class KeymapWidget(QWidget):
         # type: (KeymapWidget) -> None
         for name, entries_map in self.values.items():
             selector_widget = KeymapSelectorWidget(name, entries_map)
+            selector_widget.changed.connect(self._selectorWidgetChanged)
             self.selector_widgets[name] = selector_widget
             cat_name = self.friendlyCatName(name)
             cat = self.cat_widgets.get(cat_name)
@@ -2300,6 +2355,24 @@ class KeymapWidget(QWidget):
     def sizeHint(self):
         # type: (KeymapWidget) -> QSize
         return self.minimumSizeHint()
+
+    def _selectorWidgetChanged(self):
+        # type: (KeymapWidget) -> None
+        all_committed = True
+        for s in self.selector_widgets.values():
+            if s.committed is False:
+                self.committed = False
+                all_committed = False
+                break
+        if all_committed is True:
+            self.committed = True
+        self.changed.emit()
+
+    def revert(self):
+        # type: (KeymapWidget) -> None
+        for s in self.selector_widgets.values():
+            if s.committed is False:
+                s.revert()
 
 
 class CategoriesDelegate(QItemDelegate):

--- a/retype/ui/customisation_dialog.py
+++ b/retype/ui/customisation_dialog.py
@@ -417,14 +417,20 @@ class CustomisationDialog(QDialog):
 
     def keymapUpdate(self):
         # type: (CustomisationDialog) -> None
-        revert = False
+        revert = restore = False
 
         if self.keymap.committed is False:
             revert = True
         else:
             revert = self.config_edited != self.config
 
+        if self.keymap.isDefault() is False:
+            restore = True
+        else:
+            restore = self.config_edited != DEFAULTS
+
         self.revert_btn.setEnabled(revert)
+        self.restore_btn.setEnabled(restore)
 
     def accept(self):
         # type: (CustomisationDialog) -> None
@@ -479,6 +485,7 @@ class CustomisationDialog(QDialog):
         self.setSelectors(self.config_edited)
 
         self.theme.restoreDefaults()
+        self.keymap.restoreDefaults()
 
         self.restore_btn.setEnabled(False)
 
@@ -2373,6 +2380,21 @@ class KeymapWidget(QWidget):
         for s in self.selector_widgets.values():
             if s.committed is False:
                 s.revert()
+
+    def isDefault(self):
+        # type (KeymapWidget) -> bool
+        return self.get() == self.default_values
+
+    def restoreDefaults(self):
+        # type: (KeymapWidget) -> None
+        values = self.default_values
+        for name, widget in self.selector_widgets.items():
+            v = values.get(name, None)
+            if v is None:
+                logger.warning('KeymapWidget.restoreDefaults: Default values '
+                               f'missing for selector {name}')
+                continue
+            widget.set_(v)
 
 
 class CategoriesDelegate(QItemDelegate):

--- a/retype/ui/customisation_dialog.py
+++ b/retype/ui/customisation_dialog.py
@@ -1,5 +1,6 @@
 import os
 import logging
+import traceback
 from copy import deepcopy
 from base64 import b64encode
 from qt import (QWidget, QFormLayout, QVBoxLayout, QLabel, QLineEdit,
@@ -248,7 +249,8 @@ class CustomisationDialog(QDialog):
         pkm = QWidget()
         lyt = QFormLayout(pkm)
         lyt.setContentsMargins(0, 0, 0, 0)
-        lyt.addRow(KeymapWidget())
+        self.keymap = KeymapWidget()
+        lyt.addRow(self.keymap)
         return pkm
 
     def _consoleSettings(self):
@@ -415,6 +417,9 @@ class CustomisationDialog(QDialog):
 
         # Save theme
         self.theme.saveCurrent(getStylePath(self.getUserDir()))
+
+        # Save keymap
+        self.keymap.saveCurrent()
 
         self.revert_btn.setEnabled(False)
 
@@ -2072,6 +2077,38 @@ class KeymapSelectorWidget(QWidget):
         eargstr.setPlaceholderText("Optional arguments")
         self.lyt.addRow(eargstr, w)
 
+    def get(self):
+        # type: (KeymapSelectorWidget) -> dict[str, list[str]]
+        values = {}
+        try:
+            # 2nd row, after the selector name label
+            firsteditor = self.lyt.itemAt(
+                1, QFormLayout.ItemRole.FieldRole).widget()
+            values[''] = [firsteditor.keySequence().toString()]
+        except AttributeError:
+            logger.error("Getting KeymapSelectorWidget first editor failed."
+                         f"{traceback.format_exc()}")
+            return values
+        # Additional shortcuts starting from 4th row
+        for i in range(3, self.lyt.rowCount()):
+            try:
+                eargstr = self.lyt.itemAt(
+                    i, QFormLayout.ItemRole.LabelRole).widget()
+                w = self.lyt.itemAt(
+                    i, QFormLayout.ItemRole.FieldRole).widget()
+                editor = w.layout().itemAt(0).widget()
+                s = editor.keySequence().toString()
+            except AttributeError:
+                logger.error("Getting KeymapSelectorWidget editors failed."
+                             f"i:{i} type:{type(editor)}\n"
+                             f"{traceback.format_exc()}")
+                continue
+            if values.get(eargstr.text()):
+                values[eargstr.text()].append(s)
+            else:
+                values[eargstr.text()] = [s]
+        return values
+
 
 class KeymapCategoryWidget(QWidget):
     def __init__(self, parent=None):
@@ -2089,6 +2126,7 @@ class KeymapWidget(QWidget):
         # type: (KeymapWidget, QWidget | None) -> None
         QWidget.__init__(self, parent)
         self.cat_widgets = {}  # type: dict[str, KeymapCategoryWidget]
+        self.selector_widgets = {}  # type: dict[str, KeymapSelectorWidget]
         self.lyt = QVBoxLayout(self)
         self.lyt.setContentsMargins(0, 0, 0, 0)
         self.tabw = ScrollTabWidget()
@@ -2097,9 +2135,10 @@ class KeymapWidget(QWidget):
 
     def _populateWidgets(self):
         # type: (KeymapWidget) -> None
-        for n, k in Keymap.selectors.items():
+        for name, k in Keymap.selectors.items():
             selector_widget = KeymapSelectorWidget(k)
-            cat_name = self.friendlyCatName(n)
+            self.selector_widgets[name] = selector_widget
+            cat_name = self.friendlyCatName(name)
             cat = self.cat_widgets.get(cat_name)
             if (cat):
                 cat.addSelectorWidget(selector_widget)
@@ -2112,6 +2151,13 @@ class KeymapWidget(QWidget):
     def friendlyCatName(self, name):
         # type: (KeymapWidget, str) -> str
         return spacecamel(name.split('.')[0])
+
+    def saveCurrent(self):
+        # type: (KeymapWidget) -> None
+        values = {}
+        for name, widget in self.selector_widgets.items():
+            values[name] = widget.get()
+        Keymap.set_(values)
 
     def minimumSizeHint(self):
         # type: (KeymapWidget) -> QSize

--- a/retype/ui/customisation_dialog.py
+++ b/retype/ui/customisation_dialog.py
@@ -1,4 +1,5 @@
 import os
+import json
 import logging
 import traceback
 from copy import deepcopy
@@ -19,7 +20,7 @@ from retype.extras.dict import merge_dicts, update
 from retype.constants import default_config, iswindows, default_steno_kdict
 from retype.services.theme import (Theme, populateThemes, valuesFromQss, theme,
                                    C)
-from retype.services.keymap import Keymap
+from retype.services.keymap import Keymap, populateKeymaps
 from retype.extras.qss import serialiseValuesDict
 from retype.resource_handler import getStylePath
 from retype.extras.widgets import (ScrollTabWidget, AdjustedStackedWidget,
@@ -248,9 +249,38 @@ class CustomisationDialog(QDialog):
         # type: (CustomisationDialog) -> QWidget
         pkm = QWidget()
         lyt = QFormLayout(pkm)
-        lyt.setContentsMargins(0, 0, 0, 0)
+
+        preset_lyt = QHBoxLayout()
+        keymaps = QComboBox()
+        preset_lyt.addWidget(keymaps, 1)
+        apply_btn = QPushButton("Apply")
+        apply_btn.setToolTip("Apply selected preset")
+        preset_lyt.addWidget(apply_btn)
+        export_btn = QPushButton("Export")
+        export_btn.setToolTip("Export saved modifications as new preset")
+        preset_lyt.addWidget(export_btn)
+        lyt.addRow(QLabel("Preset:"), preset_lyt)
+        lyt.addRow(descl("To import a preset, place the json keymap file in\
+ the 'style' subfolder in either the user dir or application folder, and\
+ retart retype."))
+        lyt.addRow(descl("In the shortcut edits, Backspace or Delete to clear,\
+ Esc to unfocus."))
+
+        user_dir = self.getUserDir()
+        populateKeymaps(getStylePath(), getStylePath(user_dir))
+        for km in Keymap.keymaps:
+            keymaps.addItem(km)
+        keymaps.model().sort(0)
+        keymaps.setCurrentIndex(0)
+
         self.keymap = KeymapWidget()
         lyt.addRow(self.keymap)
+
+        apply_btn.clicked.connect(
+            lambda: self.keymap.applyKeymap(keymaps.currentText()))
+        export_btn.clicked.connect(
+            lambda: self.keymap.exportCurrent(self.getUserDir()))
+
         return pkm
 
     def _consoleSettings(self):
@@ -1939,6 +1969,7 @@ class ThemeWidget(QWidget):
         else:
             logger.warning('applyTheme: Unable to find values for theme '
                            f'{name}')
+            return
         for name, widget in self.selector_widgets.items():
             v = values.get(name, {})
             widget.set_(v)
@@ -2077,18 +2108,16 @@ class KeymapSelectorWidget(QWidget):
         eargstr.setPlaceholderText("Optional arguments")
         self.lyt.addRow(eargstr, w)
 
-    def get(self):
-        # type: (KeymapSelectorWidget) -> dict[str, list[str]]
-        values = {}
+    def widgets(self):
+        # type: (KeymapSelectorWidget) -> Iterator
         try:
             # 2nd row, after the selector name label
             firsteditor = self.lyt.itemAt(
                 1, QFormLayout.ItemRole.FieldRole).widget()
-            values[''] = [firsteditor.keySequence().toString()]
+            yield '', firsteditor.keySequence().toString(), None, firsteditor
         except AttributeError:
             logger.error("Getting KeymapSelectorWidget first editor failed."
                          f"{traceback.format_exc()}")
-            return values
         # Additional shortcuts starting from 4th row
         for i in range(3, self.lyt.rowCount()):
             try:
@@ -2098,16 +2127,43 @@ class KeymapSelectorWidget(QWidget):
                     i, QFormLayout.ItemRole.FieldRole).widget()
                 editor = w.layout().itemAt(0).widget()
                 s = editor.keySequence().toString()
+                yield eargstr.text(), s, eargstr, editor
             except AttributeError:
-                logger.error("Getting KeymapSelectorWidget editors failed."
+                logger.error("Getting KeymapSelectorWidget editors failed.\n"
                              f"i:{i} type:{type(editor)}\n"
                              f"{traceback.format_exc()}")
-                continue
-            if values.get(eargstr.text()):
-                values[eargstr.text()].append(s)
+
+    def get(self):
+        # type: (KeymapSelectorWidget) -> dict[str, list[str]]
+        values = {}
+        for argstr, s, _, _ in self.widgets():
+            if values.get(argstr):
+                values[argstr].append(s)
             else:
-                values[eargstr.text()] = [s]
+                values[argstr] = [s]
         return values
+
+    def set_(self, values):
+        # type: (KeymapSelectorWidget, dict[str, list[str]]) -> None
+        i = 0
+        remove_rows_of = []
+        for _, _, eargstr, editor in self.widgets():
+            if i == 0:
+                s = values.get('')
+                if len(s):
+                    editor.setKeySequence(s[0])
+                else:
+                    editor.clear()
+            else:
+                remove_rows_of.append(eargstr)
+            i += 1
+        for w in remove_rows_of:
+            self.lyt.removeRow(w)
+        for argstr, s in values.items():
+            if argstr == '' and len(s):
+                s = s[1:]
+            for shortcut in s:
+                self.addEntry(shortcut, argstr)
 
 
 class KeymapCategoryWidget(QWidget):
@@ -2152,12 +2208,59 @@ class KeymapWidget(QWidget):
         # type: (KeymapWidget, str) -> str
         return spacecamel(name.split('.')[0])
 
-    def saveCurrent(self):
-        # type: (KeymapWidget) -> None
+    def get(self):
+        # type: (KeymapWidget) -> dict[str, dict[str, list[str]]]
         values = {}
         for name, widget in self.selector_widgets.items():
             values[name] = widget.get()
-        Keymap.set_(values)
+        return values
+
+    def applyKeymap(self, name):
+        # type: (KeymapWidget, str) -> None
+        values = {}  # type: dict[str, dict[str, list[str]]]
+        km = Keymap.keymaps.get(name)
+        if km:
+            values = km.get('values', {})
+        else:
+            logger.warning('applyKeymap: Unable to find values for keymap '
+                           f'{name}')
+            return
+        for name, widget in self.selector_widgets.items():
+            v = values.get(name, {})
+            widget.set_(v)
+
+    def _save(self, file_path, json):
+        # type: (KeymapWidget, str, str) -> None
+        try:
+            os.makedirs(os.path.dirname(file_path), exist_ok=True)
+            with open(file_path, 'w', encoding='utf-8') as f:
+                logger.debug(f'Saving keymap: {file_path}')
+                f.write(json)
+        except OSError as e:
+            logger.error(f'Failed to save keymap to file {file_path}')
+            logger.error(f'{type(e)}: {e}')
+
+    def saveCurrent(self):
+        # type: (KeymapWidget) -> None
+        Keymap.set_(self.get())
+
+    def exportCurrent(self, user_dir):
+        # type: (KeymapWidget, str) -> None
+        # Get values dict
+        values = self.get()
+        # Serialise
+        res = json.dumps(values, indent=2)
+        # Save dialog
+        path = getStylePath(user_dir)
+        if not os.path.exists(path):
+            path = getStylePath()
+        file_path = QFileDialog.getSaveFileName(
+            self, 'Export as new keymap preset', path, 'Keymap preset (*.json)'
+        )[0]
+        if len(file_path) == 0:
+            return
+        # Write to file in path
+        self._save(file_path, res)
 
     def minimumSizeHint(self):
         # type: (KeymapWidget) -> QSize

--- a/style/keymapdefault.json
+++ b/style/keymapdefault.json
@@ -1,0 +1,88 @@
+{
+  "Menu.reportIssue": {
+    "": [
+      ""
+    ]
+  },
+  "Menu.documentation": {
+    "": [
+      ""
+    ]
+  },
+  "Menu.about": {
+    "": [
+      ""
+    ]
+  },
+  "Menu.showSteno": {
+    "": [
+      ""
+    ]
+  },
+  "Menu.showTypespeed": {
+    "": [
+      ""
+    ]
+  },
+  "Menu.toggleConsoleWindow": {
+    "": [
+      ""
+    ]
+  },
+  "Menu.showCustomisationDialog": {
+    "": [
+      "Ctrl+O"
+    ]
+  },
+  "Menu.setViewByEnum": {
+    "": [
+      ""
+    ],
+    "1": [
+      "Ctrl+1"
+    ],
+    "2": [
+      "Ctrl+2"
+    ]
+  },
+  "Menu.quit": {
+    "": [
+      "Alt+F4"
+    ]
+  },
+  "BookView.zoomOut": {
+    "": [
+      "Ctrl+-"
+    ]
+  },
+  "BookView.zoomIn": {
+    "": [
+      "Ctrl++"
+    ]
+  },
+  "BookView.skipLine": {
+    "": [
+      ""
+    ]
+  },
+  "BookView.nextChapter": {
+    "": [
+      ""
+    ]
+  },
+  "BookView.previousChapter": {
+    "": [
+      ""
+    ]
+  },
+  "BookView.switchToShelves": {
+    "": [
+      ""
+    ]
+  },
+  "BookView.gotoCursorPosition": {
+    "": [
+      ""
+    ]
+  }
+}


### PR DESCRIPTION
#48

Keyboard shortcuts customisation similar to how we do themes.

- Each widget can define keyboard shortcuts with the `keymap` decorator. For example `@keymap('Menu.quit', K(['Alt+F4']))`, where `Menu.quit` is the selector name, and `Alt+F4` is the default shortcut. There can be several default shortcuts.
- It is permitted to define commands without a default shortcut. For example `@keymap('Menu.about', K())`.
- In addition, `K` can be given a dictionary where the keys are argument strings, and the values are a list of shortcuts. For example `@keymap('Menu.setViewByEnum', K([], {'1': ['Ctrl+1'], '2': ['Ctrl+2']}))` means no default shortcuts with no arguments, `Ctrl+1` shortcut for calling it with argument 1, `Ctrl+2` shortcut for calling it with argument 2.
- Argument strings are arbitrary. Widgets decide how and whether to handle them. There is no validation.
- Keyboard shortcuts are set on QActions. To function, QActions must be in a menu or a toolbar or bound to a QWidget in some other way (you can do `addAction` on any QWidget).
- We currently only have two widgets that define shortcuts: MenuController and BookView. Each of them does this by defining an actions dictionary where the keys are the selector names followed by the argument string (e.g. 'Menu.setViewByEnum:1', 'Menu.setViewByEnum:2'), then the actions are created by iterating the dictionary. The shortcuts for each action can be obtained with: `Keymap.s(selector_name).s(argstr)`.
- There is support for Emacs-like shortcuts, with multiple chords (Qt supports this by default)

The underlying data is `dict[str, dict[str, list[str]]]` (dictionary where the keys are selector names, and the values are a dictionary where the keys are argument strings, and the values are lists of shortcuts). Example:
```json
{
  "Menu.setViewByEnum": {
    "": [
      ""
    ],
    "1": [
      "Ctrl+1"
    ],
    "2": [
      "Ctrl+2"
    ]
  },
  "Menu.quit": {
    "": [
      "Alt+F4"
    ]
  }
}
```

Customisation:
- Like for theme, each "category" appears in its own tab. Category is the first part of the selector name before the `.`. We currently have Menu and Book View.
- Each category contains selector widgets for each selector in it. The selector names appear in bold.
- Each selector has a "primary shortcut" that cannot be deleted (though it can be cleared) that has an empty argument string. That is the first shortcut with no arguments. There is an add button to add additional entries. Each entry is a row composed of an argument string editor, a key sequence editor, and a remove button. The argument string can be left empty. Entries that lack both an argument string and shortcut are ignored.
- Key sequence edits can be cleared by pressing Backspace or Delete with no modifiers, and unfocused by pressing Esc with no modifiers.
- There is a revert button that appears next to the selector name after modifications (changing key sequence edits, argument string edits, adding or deleting non-empty entries) that permits to return to the state of the last save.
- Restore defaults permits to return to the state of shortcuts as defined by the widget decorators.
- Like with themes, it's possible to export and apply presets. The presets are json files in the style subdirectory of either the application directory or the userdir, in the format shown above.
- Operating-system-specific actions (currently there's only Menu.toggleConsoleWindow) appear in customisation regardless of operating system, but the corresponding QActions don't get created on other OS, so will not do anything. I chose to show them anyway, since they're on the keymap.

I think that covers it. I might have forgotten something. That was a lot of work over the past couple of days, even though it is very similar to how themes are done already. It needs more testing, but I think I will merge it and apply any fixes as separate PRs.