### PR TITLE
feat(Keymap): Support for more argstrs

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -236,14 +236,15 @@ Files: .github/workflows/Dockerfile
        retype/controllers/__init__.py
        retype/controllers/library.py
        retype/controllers/safe_config.py
-       retype/controllers/extras/__init__.py
-       retype/controllers/extras/camel.py
-       retype/controllers/extras/log.py
-       retype/controllers/extras/metatypes.py
-       retype/controllers/extras/qss.py
-       retype/controllers/extras/space.py
-       retype/controllers/extras/split.py
-       retype/controllers/extras/str_subclasses.py
+       retype/extras/__init__.py
+       retype/extras/actions.py
+       retype/extras/camel.py
+       retype/extras/log.py
+       retype/extras/metatypes.py
+       retype/extras/qss.py
+       retype/extras/space.py
+       retype/extras/split.py
+       retype/extras/str_subclasses.py
        retype/layouts/__init__.py
        retype/layouts/rowlayout.doctest
        retype/layouts/rowlayout.py

--- a/retype/controllers/menu_controller.py
+++ b/retype/controllers/menu_controller.py
@@ -1,15 +1,10 @@
-import logging
-import traceback
-from qt import QAction, QObject
+from qt import QObject
 
 from typing import TYPE_CHECKING
 
 from retype.constants import (
     RETYPE_ISSUE_TRACKER_URL, RETYPE_DOCUMENTATION_URL, iswindows)
-from retype.resource_handler import getIcon
-from retype.services.keymap import keymap, K, Keymap
-
-logger = logging.getLogger(__name__)
+from retype.services.keymap import keymap, K, Keymap, genActions, keymapUpdate
 
 
 @keymap('Menu.quit', K(['Alt+F4']))
@@ -28,7 +23,8 @@ class MenuController(QObject):
         self.controller = main_controller
         self._menu = menu
         self._initMenuBar()
-        Keymap.notifier.changed.connect(self.keymapUpdate)
+        Keymap.notifier.changed.connect(
+            lambda: keymapUpdate(self.actions, self._menu))
 
     def _initMenuBar(self):
         # type: (MenuController) -> None
@@ -47,6 +43,8 @@ class MenuController(QObject):
                 'menu': viewMenu, 'name': '&Shelf View',
                 'func': lambda: self.controller.setViewByEnum(1),
                 'icon': 'shelf_view',
+                'args_regex': r'[1-2]',
+                'args_func': lambda d: self.controller.setViewByEnum(int(d)),
             },
             'Menu.setViewByEnum:2': {
                 'menu': viewMenu, 'name': '&Book View',
@@ -88,77 +86,12 @@ class MenuController(QObject):
                     RETYPE_ISSUE_TRACKER_URL),
                 'icon': 'issue',
             },
-        }  # type: dict[str, ActionInfo]
+        }  # type: ActionsInfo
 
-        for name, info in self.actions.items():
-            n = name.split(':')
-            selector_name = n[0]
-            argstr = n[1] if len(n) > 1 else ''
-            info['shortcuts'] = Keymap.s(selector_name).s(argstr)
-            if info.pop('condition', True):
-                before = info.pop('before', None)
-                if before:
-                    before()
-                action = self._addAction(**info)
-                info['action'] = action
-
-    def _makeAction(self,  # type: MenuController
-                    name,  # type: str
-                    func,  # type: Callable[[], None]
-                    shortcuts=None,  # type: list[str] | None
-                    icon_name=None  # type: str | None
-                    ):
-        # type: (...) -> QAction
-        action = QAction(name, self)
-        action.triggered.connect(func)
-        if shortcuts:
-            action.setShortcuts(shortcuts)
-        if icon_name:
-            action.setIcon(getIcon(icon_name))
-        return action
-
-    def _addAction(self,  # type: MenuController
-                   menu,  # type: QMenu
-                   name,  # type: str
-                   func,  # type: Callable[[], None]
-                   shortcuts=None,  # type: list[str] | None
-                   icon=None  # type: str | None
-                   ):
-        # type: (...) -> QAction
-        action = self._makeAction(name, func, shortcuts, icon)
-        menu.addAction(action)
-        return action
-
-    def keymapUpdate(self):
-        # type: (MenuController) -> None
-        if not hasattr(self, 'actions'):
-            logger.warning("keymapUpdate called with no actions set")
-            return
-        for name, d in self.actions.items():
-            n = name.split(':')
-            selector_name = n[0]
-            argstr = n[1] if len(n) > 1 else ''
-            try:
-                s = Keymap.s(selector_name).s(argstr)
-                d['shortcuts'] = s
-                # Action could be None for OS-specific actions
-                action = d.get('action')
-                if action:
-                    action.setShortcuts(s)
-                else:
-                    logger.debug(f"Skip updating non-existing action {name}")
-            except (KeyError, AttributeError):
-                logger.error(f"Updating k '{name}' failed. "
-                             f"{traceback.format_exc()}")
+        genActions(self.actions)
 
 
 if TYPE_CHECKING:
-    from qt import QMenu, QMenuBar, QKeySequence  # noqa: F401
+    from qt import QMenu, QMenuBar  # noqa: F401
     from retype.controllers import MainController  # noqa: F401
-    from typing import Callable, TypedDict  # noqa: F401
-    ActionInfo = TypedDict(
-        'ActionInfo',
-        {'menu': QMenu, 'name': str, 'func': Callable[[], None],
-         'tooltip': str, 'shortcuts': list[str], 'icon': str,
-         'action': QAction, 'condition': bool, 'before': Callable[[], None]},
-        total=False)
+    from retype.extras.metatypes import ActionsInfo  # noqa: F401

--- a/retype/controllers/menu_controller.py
+++ b/retype/controllers/menu_controller.py
@@ -36,52 +36,53 @@ class MenuController(QObject):
 
         self.actions = {
             'Menu.quit': {
-                'menu': fileMenu, 'name': '&Quit',
+                'widget': fileMenu, 'name': '&Quit',
                 'func': self.controller.quit, 'icon': 'door',
             },
             'Menu.setViewByEnum:1': {
-                'menu': viewMenu, 'name': '&Shelf View',
+                'widget': viewMenu, 'name': '&Shelf View',
                 'func': lambda: self.controller.setViewByEnum(1),
                 'icon': 'shelf_view',
                 'args_regex': r'[1-2]',
                 'args_func': lambda d: self.controller.setViewByEnum(int(d)),
             },
             'Menu.setViewByEnum:2': {
-                'menu': viewMenu, 'name': '&Book View',
+                'widget': viewMenu, 'name': '&Book View',
                 'func': lambda: self.controller.setViewByEnum(2),
                 'icon': 'open_book',
             },
             'Menu.toggleConsoleWindow': {
-                'menu': viewMenu, 'name': 'Toggle System &Console',
+                'widget': viewMenu, 'name': 'Toggle System &Console',
                 'func': lambda: self.controller.toggleConsoleWindow(),
                 'icon': 'console', 'condition': iswindows,
                 'before': viewMenu.addSeparator,
             },
             'Menu.showTypespeed': {
-                'menu': gamesMenu, 'name': '&Typespeed',
+                'widget': gamesMenu, 'name': '&Typespeed',
                 'func': self.controller.showTypespeed, 'icon': 'typespeed',
             },
             'Menu.showSteno': {
-                'menu': gamesMenu, 'name': '&Learn Stenography',
+                'widget': gamesMenu, 'name': '&Learn Stenography',
                 'func': self.controller.showSteno, 'icon': 'steno',
             },
             'Menu.showCustomisationDialog': {
-                'menu': optionsMenu, 'name': '&Customise retype',
+                'widget': optionsMenu, 'name': '&Customise retype',
                 'func': self.controller.showCustomisationDialog,
                 'icon': 'customise',
             },
             'Menu.about': {
-                'menu': helpMenu, 'name': "&About",
+                'widget': helpMenu, 'name': "&About",
                 'func': self.controller.showAboutDialog, 'icon': 'about',
             },
             'Menu.documentation': {
-                'menu': helpMenu, 'name': "&Documentation (opens in browser)",
+                'widget': helpMenu,
+                'name': "&Documentation (opens in browser)",
                 'func': lambda: self.controller.openUrl(
                     RETYPE_DOCUMENTATION_URL),
                 'icon': 'documentation',
             },
             'Menu.reportIssue': {
-                'menu': helpMenu, 'name': '&Report issue (opens in browser)',
+                'widget': helpMenu, 'name': '&Report issue (opens in browser)',
                 'func': lambda: self.controller.openUrl(
                     RETYPE_ISSUE_TRACKER_URL),
                 'icon': 'issue',

--- a/retype/extras/actions.py
+++ b/retype/extras/actions.py
@@ -5,26 +5,24 @@ from typing import TYPE_CHECKING
 from retype.resource_handler import getIcon
 
 
-def makeAction(name,  # type: str
-               func,  # type: Callable[[], None]
+def makeAction(name=None,  # type: str | None
+               func=None,  # type: Callable[[], None] | None
                tooltip=None,  # type: str | None
                shortcuts=None,  # type: list[str] | None
                icon=None,  # type: str | None
-               menu=None,  # type: QWidget
-               widget=None,  # type: QWidget
+               widget=None,  # type: QWidget | None
                **_
                ):
     # type: (...) -> QAction
     action = QAction(name)
-    action.triggered.connect(func)
+    if func:
+        action.triggered.connect(func)
     if tooltip:
         action.setToolTip(tooltip)
     if shortcuts:
         action.setShortcuts(shortcuts)
     if icon:
         action.setIcon(getIcon(icon))
-    if menu:
-        menu.addAction(action)
     if widget:
         widget.addAction(action)
     return action

--- a/retype/extras/actions.py
+++ b/retype/extras/actions.py
@@ -1,0 +1,35 @@
+from qt import QAction
+
+from typing import TYPE_CHECKING
+
+from retype.resource_handler import getIcon
+
+
+def makeAction(name,  # type: str
+               func,  # type: Callable[[], None]
+               tooltip=None,  # type: str | None
+               shortcuts=None,  # type: list[str] | None
+               icon=None,  # type: str | None
+               menu=None,  # type: QWidget
+               widget=None,  # type: QWidget
+               **_
+               ):
+    # type: (...) -> QAction
+    action = QAction(name)
+    action.triggered.connect(func)
+    if tooltip:
+        action.setToolTip(tooltip)
+    if shortcuts:
+        action.setShortcuts(shortcuts)
+    if icon:
+        action.setIcon(getIcon(icon))
+    if menu:
+        menu.addAction(action)
+    if widget:
+        widget.addAction(action)
+    return action
+
+
+if TYPE_CHECKING:
+    from qt import QWidget  # noqa: F401
+    from typing import Callable  # noqa: F401

--- a/retype/extras/metatypes.py
+++ b/retype/extras/metatypes.py
@@ -23,7 +23,7 @@ CommandsInfo = dict[str, CommandInfo]
 
 ActionInfo = TypedDict(
     'ActionInfo',
-    {'menu': QWidget, 'widget': QWidget, 'widget_ui': QWidget, 'name': str,
+    {'widget': QWidget, 'widget_ui': QWidget, 'name': str,
      'func': Callable[[], None], 'func_ui': Callable[[], None],
      'tooltip': str, 'shortcuts': list[str], 'icon': str,
      'action': QAction, 'action_ui': QAction,

--- a/retype/extras/metatypes.py
+++ b/retype/extras/metatypes.py
@@ -8,7 +8,7 @@ from retype.games.typespeed import TypespeedView as TypespeedV
 from retype.games.steno import StenoView
 from retype.controllers.main_controller import View
 from retype.extras.dict import _NestedSafeDictGroup
-from qt import QWidget, pyqtBoundSignal
+from qt import QWidget, pyqtBoundSignal, QMenu, QAction
 
 NestedDict = Dict[object, Union[object, 'NestedDict']]
 NestedMapping = Mapping[object, Union[object, 'NestedMapping']]
@@ -20,6 +20,14 @@ CommandInfo = TypedDict(
      'func': Callable[[], None]},
     total=False)
 CommandsInfo = dict[str, CommandInfo]
+
+ActionInfo = TypedDict(
+    'ActionInfo',
+    {'menu': QMenu, 'name': str, 'func': Callable[[], None],
+     'tooltip': str, 'shortcuts': list[str], 'icon': str,
+     'action': QAction, 'condition': bool, 'before': Callable[[], None]},
+    total=False)
+ActionsInfo = dict[str, ActionInfo]
 
 SaveData = TypedDict(
     'SaveData',

--- a/retype/extras/metatypes.py
+++ b/retype/extras/metatypes.py
@@ -8,7 +8,7 @@ from retype.games.typespeed import TypespeedView as TypespeedV
 from retype.games.steno import StenoView
 from retype.controllers.main_controller import View
 from retype.extras.dict import _NestedSafeDictGroup
-from qt import QWidget, pyqtBoundSignal, QMenu, QAction
+from qt import QWidget, pyqtBoundSignal, QAction
 
 NestedDict = Dict[object, Union[object, 'NestedDict']]
 NestedMapping = Mapping[object, Union[object, 'NestedMapping']]
@@ -23,9 +23,12 @@ CommandsInfo = dict[str, CommandInfo]
 
 ActionInfo = TypedDict(
     'ActionInfo',
-    {'menu': QMenu, 'name': str, 'func': Callable[[], None],
+    {'menu': QWidget, 'widget': QWidget, 'widget_ui': QWidget, 'name': str,
+     'func': Callable[[], None], 'func_ui': Callable[[], None],
      'tooltip': str, 'shortcuts': list[str], 'icon': str,
-     'action': QAction, 'condition': bool, 'before': Callable[[], None]},
+     'action': QAction, 'action_ui': QAction,
+     'condition': bool, 'before': Callable[[], None],
+     'args_regex': str, 'args_func': Callable[[str], None]},
     total=False)
 ActionsInfo = dict[str, ActionInfo]
 

--- a/retype/services/keymap.py
+++ b/retype/services/keymap.py
@@ -1,10 +1,13 @@
 import os
+import re
 import json
 import logging
 import traceback
 from qt import QObject, pyqtSignal
 
 from typing import TYPE_CHECKING
+
+from retype.extras.actions import makeAction
 
 logger = logging.getLogger(__name__)
 
@@ -115,6 +118,69 @@ def populateKeymaps(app_path, user_path):
             break  # do not recurse
 
 
+def genActions(actions, widget=None):
+    # type: (ActionsInfo, QWidget | None) -> None
+    """Utility function to generate QActions from a ActionInfo dict"""
+    for name, info in actions.items():
+        n = name.split(':')
+        selector_name = n[0]
+        argstr = n[1] if len(n) > 1 else ''
+        info['shortcuts'] = Keymap.s(selector_name).s(argstr)
+        if info.get('condition', True):
+            before = info.pop('before', None)
+            if before:
+                before()
+            action = makeAction(**info, widget=widget)
+            info['action'] = action
+
+
+def keymapUpdate(actions, widget):
+    # type: (ActionsInfo, QWidget) -> None
+    """Utility function to update QActions shortcuts"""
+    logger.debug(f'keymapUpdate for {type(widget)}')
+    # 1. Remove any previously created custom actions
+    custom_actions = getattr(keymapUpdate, 'custom_actions', [])
+    for a in custom_actions:
+        a['widget'].removeAction(a['action'])
+    custom_actions = []
+    # Update bindings for actions in actions dictionary
+    for name, d in actions.items():
+        if not d.get('condition', True):
+            continue
+        n = name.split(':')
+        selector_name = n[0]
+        argstr = n[1] if len(n) > 1 else ''
+        try:
+            s = Keymap.s(selector_name).s(argstr)
+            d['shortcuts'] = s
+            action = d['action']
+            action.setShortcuts(s)
+        except (KeyError, AttributeError):
+            logger.error(f"Updating k '{name}' failed. "
+                         f"{traceback.format_exc()}")
+        # Create custom actions based on bindings that lack actions
+        for argstr, s in Keymap.s(selector_name).entries():
+            if not s or s == ['']:
+                continue
+            combined_name = selector_name
+            combined_name += f':{argstr}' if argstr else ''
+            if combined_name in actions:
+                continue
+            regex = d.get('args_regex')
+            func = d.get('args_func')
+            if not (regex and func) or not re.match(regex, argstr):
+                continue
+            action = makeAction(
+                combined_name, lambda _, f=func, a=argstr: f(a))
+            action.setShortcuts(s)
+            custom_actions.append({'action': action, 'widget': widget})
+            widget.addAction(action)
+            logger.debug(
+                f'keymapUpdate: Created custom action {combined_name}')
+    keymapUpdate.custom_actions = custom_actions
+    logger.debug(f'keymapUpdate.custom_actions = {custom_actions}')
+
+
 def keymap(selector, k):
     # type: (str, K) -> Callable[[type[T]], type[T]]
     def decorator(cls):
@@ -127,6 +193,7 @@ def keymap(selector, k):
 
 if TYPE_CHECKING:
     from typing import Callable, TypeVar, TypedDict  # noqa: F401
+    from retype.extras.metatypes import ActionsInfo  # noqa: F401
     T = TypeVar('T')
     ValuesDict = dict[str, dict[str, list[str]]]
     KeymapData = TypedDict(

--- a/retype/services/keymap.py
+++ b/retype/services/keymap.py
@@ -125,13 +125,21 @@ def genActions(actions, widget=None):
         n = name.split(':')
         selector_name = n[0]
         argstr = n[1] if len(n) > 1 else ''
-        info['shortcuts'] = Keymap.s(selector_name).s(argstr)
+        s = Keymap.s(selector_name).s(argstr)
         if info.get('condition', True):
             before = info.pop('before', None)
             if before:
                 before()
-            action = makeAction(**info, widget=widget)
+            widget = info.pop('widget', None) or widget
+            widget_ui = info.pop('widget_ui', None)
+            func = info.pop('func', None)
+            func_ui = info.pop('func_ui', None)
+            if widget_ui and func_ui:
+                action_ui = makeAction(**info, widget=widget_ui, func=func_ui)
+                info['action_ui'] = action_ui
+            action = makeAction(**info, widget=widget, func=func, shortcuts=s)
             info['action'] = action
+            info['shortcuts'] = s
 
 
 def keymapUpdate(actions, widget):

--- a/retype/ui/book_view.py
+++ b/retype/ui/book_view.py
@@ -267,63 +267,79 @@ class BookView(QWidget):
             {
                 'name': 'Back to shelves',
                 'func': self.switchToShelves,
+                'widget': self.toolbar,
             },
             'BookView.gotoCursorPosition':
             {
                 'name': 'Cursor position',
                 'func': self.gotoCursorPosition,
+                'func_ui': self.gotoCursorPositionAction,
                 'tooltip': 'Go to the cursor position. Hold Ctrl to move\
  cursor to your current position',
                 'icon': 'cursor',
+                'widget': self.toolbar,
+                'widget_ui': self,
                 'args_regex': '(m|move)',
                 'args_func': lambda m: self.gotoCursorPosition(move=True),
             },
             'BookView.previousChapter':
             {
                 'name': 'Previous chapter',
-                'func': self.previousChapterAction,
+                'func': self.previousChapter,
+                'func_ui': self.previousChapterAction,
                 'tooltip': 'Go to the previous chapter. Hold Ctrl to move\
  cursor with you as well',
                 'icon': 'arrow-left',
                 'args_regex': '(m|move)',
                 'args_func': lambda m: self.previousChapter(move_cursor=True),
+                'widget': self,
+                'widget_ui': self.toolbar,
             },
             'BookView.nextChapter':
             {
                 'name': 'Next chapter',
-                'func': self.nextChapterAction,
+                'func': self.nextChapter,
+                'func_ui': self.nextChapterAction,
                 'tooltip': 'Go to the next chapter. Hold Ctrl to move cursor\
  with you as well',
                 'icon': 'arrow-right',
                 'args_regex': '(m|move)',
                 'args_func': lambda m: self.nextChapter(move_cursor=True),
+                'widget': self,
+                'widget_ui': self.toolbar,
             },
             'BookView.skipLine':
             {
                 'name': 'Skip line',
                 'func': self.advanceLine,
                 'tooltip': 'Move cursor to next line',
-                'icon': 'skip'
+                'icon': 'skip',
+                'widget': self.toolbar,
             },
             'BookView.zoomIn':
             {
                 'name': 'Increase font size',
                 'func': self.display.zoomIn,
-                'icon': 't-up'
+                'icon': 't-up',
+                'widget': self.toolbar,
             },
             'BookView.zoomOut':
             {
                 'name': 'Decrease font size',
                 'func': self.display.zoomOut,
-                'icon': 't-down'
+                'icon': 't-down',
+                'widget': self.toolbar,
             }
         }  # type: ActionsInfo
 
-        genActions(self.actions, self.toolbar)
+        genActions(self.actions)
 
-        self.pchap_action = self.actions['BookView.previousChapter']['action']
-        self.nchap_action = self.actions['BookView.nextChapter']['action']
-        self.skip_action = self.actions['BookView.skipLine']['action']
+        self.pchap_action = self.actions[
+            'BookView.previousChapter']['action_ui']
+        self.nchap_action = self.actions[
+            'BookView.nextChapter']['action_ui']
+        self.skip_action = self.actions[
+            'BookView.skipLine']['action']
 
         self.toolbar.insertSeparator(
             self.actions['BookView.gotoCursorPosition']['action'])
@@ -636,14 +652,21 @@ class BookView(QWidget):
         # type: (BookView, bool) -> None
         if self.chapter_pos is None:
             return
-        if move or (self._keyboardModifiers() == Qt.KeyboardModifiers(
-                Qt.KeyboardModifier.ControlModifier)):
+        if move:
             self.setChapter(self.viewed_chapter_pos, True)
             self.updateProgress()
         else:
             self.setChapter(self.chapter_pos)
             self.setCursor()
             self.display.centreAroundCursor()
+
+    def gotoCursorPositionAction(self):
+        # type: (BookView) -> None
+        if self._keyboardModifiers() == Qt.KeyboardModifiers(
+                Qt.KeyboardModifier.ControlModifier):
+            self.gotoCursorPosition(True)
+        else:
+            self.gotoCursorPosition(False)
 
     def updateToolbarActions(self):
         # type: (BookView) -> None

--- a/retype/ui/book_view.py
+++ b/retype/ui/book_view.py
@@ -1,5 +1,4 @@
 import logging
-import traceback
 from qt import (QWidget, QVBoxLayout, QTextBrowser, QTextDocument, QUrl,
                 QTextCursor, QTextCharFormat, QPainter, QPixmap,
                 QToolBar, QFont, QKeySequence, Qt, QApplication, pyqtSignal,
@@ -11,9 +10,8 @@ from retype.extras import splittext, isspaceorempty, ManifoldStr
 from retype.ui.modeline import Modeline
 from retype.services import Autosave
 from retype.stats import StatsDock
-from retype.resource_handler import getIcon
 from retype.services.theme import theme, C, Theme
-from retype.services.keymap import keymap, K, Keymap
+from retype.services.keymap import keymap, K, Keymap, genActions, keymapUpdate
 from retype.constants import default_font_family, default_font_size
 
 logger = logging.getLogger(__name__)
@@ -217,7 +215,8 @@ class BookView(QWidget):
         self.c_mistake.changed.connect(self.themeUpdate)
         self.themeUpdate()
 
-        Keymap.notifier.changed.connect(self.keymapUpdate)
+        Keymap.notifier.changed.connect(
+            lambda: keymapUpdate(self.actions, self))
 
     def _loadTheme(self):
         # type: (BookView) -> tuple[C, ...]
@@ -228,23 +227,6 @@ class BookView(QWidget):
         # type: (BookView) -> None
         self.mistake_format.setForeground(self.c_mistake.fg())
         self.mistake_format.setBackground(self.c_mistake.bg())
-
-    def keymapUpdate(self):
-        # type: (BookView) -> None
-        if not hasattr(self, 'actions'):
-            logger.warning("keymapUpdate called with no actions set")
-            return
-        for name, d in self.actions.items():
-            n = name.split(':')
-            selector_name = n[0]
-            argstr = n[1] if len(n) > 1 else ''
-            try:
-                s = Keymap.s(selector_name).s(argstr)
-                d['shortcuts'] = s
-                d['action'].setShortcuts(s)
-            except KeyError:
-                logger.error(f"Updating k '{name}' failed with KeyError. "
-                             f"{traceback.format_exc()}")
 
     def _initUI(self):
         # type: (BookView) -> None
@@ -292,7 +274,9 @@ class BookView(QWidget):
                 'func': self.gotoCursorPosition,
                 'tooltip': 'Go to the cursor position. Hold Ctrl to move\
  cursor to your current position',
-                'icon': 'cursor'
+                'icon': 'cursor',
+                'args_regex': '(m|move)',
+                'args_func': lambda m: self.gotoCursorPosition(move=True),
             },
             'BookView.previousChapter':
             {
@@ -300,7 +284,9 @@ class BookView(QWidget):
                 'func': self.previousChapterAction,
                 'tooltip': 'Go to the previous chapter. Hold Ctrl to move\
  cursor with you as well',
-                'icon': 'arrow-left'
+                'icon': 'arrow-left',
+                'args_regex': '(m|move)',
+                'args_func': lambda m: self.previousChapter(move_cursor=True),
             },
             'BookView.nextChapter':
             {
@@ -308,7 +294,9 @@ class BookView(QWidget):
                 'func': self.nextChapterAction,
                 'tooltip': 'Go to the next chapter. Hold Ctrl to move cursor\
  with you as well',
-                'icon': 'arrow-right'
+                'icon': 'arrow-right',
+                'args_regex': '(m|move)',
+                'args_func': lambda m: self.nextChapter(move_cursor=True),
             },
             'BookView.skipLine':
             {
@@ -329,32 +317,9 @@ class BookView(QWidget):
                 'func': self.display.zoomOut,
                 'icon': 't-down'
             }
-        }  # type: dict[str, ActionInfo]
+        }  # type: ActionsInfo
 
-        def addAction(name,  # type: str
-                      func,  # type: Callable[[], None]
-                      tooltip=None,  # type: str | None
-                      shortcuts=None,  # type: list[Shortcut] | None
-                      icon=None,  # type: str | None
-                      action=None  # type: QAction | None  # unused
-                      ):
-            # type: (...) -> QAction
-            a = self.toolbar.addAction(name, func)
-            if tooltip:
-                a.setToolTip(tooltip)
-            if shortcuts:
-                a.setShortcuts(shortcuts)
-            if icon:
-                a.setIcon(getIcon(icon))
-            return a
-
-        for name, info in self.actions.items():
-            n = name.split(':')
-            selector_name = n[0]
-            argstr = n[1] if len(n) > 1 else ''
-            info['shortcuts'] = Keymap.s(selector_name).s(argstr)
-            action = addAction(**info)
-            info['action'] = action
+        genActions(self.actions, self.toolbar)
 
         self.pchap_action = self.actions['BookView.previousChapter']['action']
         self.nchap_action = self.actions['BookView.nextChapter']['action']
@@ -750,10 +715,5 @@ if TYPE_CHECKING:
     from retype.controllers import MainController  # noqa: F401
     from typing import Union, Callable, Dict, TypedDict, Never  # noqa: F401
     from retype.extras.metatypes import (  # noqa: F401
-        SaveData, BookViewSettings, Chapter, SDict, RDict, Book)
+        SaveData, BookViewSettings, Chapter, SDict, RDict, Book, ActionsInfo)
     Shortcut = Union[QKeySequence, QKeySequence.StandardKey, str, int]
-    ActionInfo = TypedDict(
-        'ActionInfo',
-        {'name': str, 'func': Callable[[], None], 'tooltip': str,
-         'shortcuts': list[str], 'icon': str, 'action': QAction},
-        total=False)


### PR DESCRIPTION
I have come to this interface: Each widget with actions defines a dictionary with information about the actions, calls `genActions` to create them, and connects itself to `keymapUpdate`.

The dictionary can contain the following information about each action (all optional):
- `widget` : The widget to add the action to.
- `widget_ui` : The widget to add a 2nd action to, which will be connected to `func_ui` instead of `func`, and will not have any shortcuts defined.
- `name` : Display text. Doesn't do anything unless `widget` or `widget_ui` are a menu or toolbar, in which case it will be the display text for that entry in the menu or toolbar.
- `func` : Function to connect to the action.
- `func_ui` : Function to connect to the 2nd action if `widget_ui` is provided.
- `tooltip` : The tooltip for that entry in the menu or toolbar, if `widget` or `widget_ui` are a menu or toolbar.
- `icon` : The name of the icon in the iconset to apply to the action.
- `condition` : A boolean for whether to add the action. Used for OS-specific actions to avoid adding them on the wrong OS.
- `before` : Function to call before adding the action.
- `args_regex` : Regex of accepted argstrs.
- `args_func` : Function that should take a string, and will be connected to the custom actions created dynamically for user keyboard bindings with accepted argstrs.

The other parameters you can see on ActionInfo (`shortcuts`, `action`, `action_ui`) are added dynamically and should not be provided (they will be ignored).

The purpose for having `widget` and `widget_ui`, `func` and `func_ui`, is we have some actions (gotoCursorPosition, nextChapter, previousChapter) where the UI button should behave differently than the action we want to take place for the keyboard shortcuts. For those toolbar actions, when Ctrl is pressed they move the cursor also (equivalent to argstr m/move). That means that if we used the same actions for the keyboard shortcuts, if they keyboard shortcut happens to have Ctrl in it, it will move the cursor regardless of the argstr. To get around it, those actions define a separate function and widget for which to create an action that will only be used for the UI button and not keyboard shortcuts.

Lastly, I will try to explain how argstrs work. Each time keymapUpdate is called (which is once at launch, and when it changes) if there are user bindings with a supported argstr (based on whether they match `args_regex`), custom actions are created with those shortcuts. Each time, keymapUpdate removes and recreates these custom actions, which it stores on itself. That way they can be kept up to date with the user bindings and not leak.

Previously `keymapUpdate` was a method on each widget to define itself, like `themeUpdate`, but now there is a lot of logic there, so it's been moved to `keymap.py`.