### PR TITLE
fix(Keymap): Don't create keymapSelectorWidgets for nonexistent

### DIFF
--- a/retype/ui/customisation_dialog.py
+++ b/retype/ui/customisation_dialog.py
@@ -2281,7 +2281,9 @@ class KeymapWidget(QWidget):
             logger.debug(f'Current keymap {file_path} not found. This is\
  normal on first launch or if it has not been saved yet. Falling back to\
  default values.')
-        return values or self.default_values
+        # Filter out selectors that don't exist
+        values = values or self.default_values
+        return {s: values[s] for s in self.default_values.keys()}
 
     def _populateWidgets(self, values):
         # type: (KeymapWidget, dict[str, dict[str, list[str]]]) -> None


### PR DESCRIPTION
In customisation, don't create keymapSelectorWidgets for selectors in the user keymap that don't really exist.

After loading the user's keymap, filter out the selectors that don't exist in keymapWidget's values.