### PR TITLE
fix(Keymap): Use re.fullmatch instead of re.match in argstr matching

### DIFF
--- a/retype/services/keymap.py
+++ b/retype/services/keymap.py
@@ -180,7 +180,7 @@ def keymapUpdate(actions, widget):
                 continue
             regex = d.get('args_regex')
             func = d.get('args_func')
-            if not (regex and func) or not re.match(regex, argstr):
+            if not (regex and func) or not re.fullmatch(regex, argstr):
                 continue
             action = makeAction(
                 combined_name, lambda _, f=func, a=argstr: f(a))


### PR DESCRIPTION
Otherwise argstrs could be considered valid if the regex doesn't have $ at the end and they have more text after the match.