### PR TITLE
fix(BookView): setChapter large negative indices out of range

### DIFF
--- a/retype/ui/book_view.py
+++ b/retype/ui/book_view.py
@@ -502,11 +502,15 @@ class BookView(QWidget):
                          f'chapter_pos: {self.chapter_pos}')
             return
 
-        if len(self.book.chapters) > pos:
+        # Normalise negative indices
+        pos = pos if pos > 0 else len(self.book.chapters) + pos
+
+        # Check pos is in range
+        if 0 < pos < len(self.book.chapters):
             self.setSource(self.book.chapters[pos])
         else:
-            logger.error(f'setChapter: pos {pos} exceeds '
-                         f'{len(self.book.chapters)} chapters')
+            logger.error(f'setChapter: pos {pos} is out of range '
+                         f'(num chapters: {len(self.book.chapters)})')
             return
 
         self.viewed_chapter_pos = pos

--- a/tests/test_book_view.py
+++ b/tests/test_book_view.py
@@ -1,12 +1,36 @@
 from qt import pyqtSignal, QObject
+from unittest.mock import patch, MagicMock
 
 from retype.ui import BookView
 
 
+class FakeBook:
+    chapters = [{'html': 'waeofiaw', 'plain': 'waeofiaw', 'images': []}]*5
+    title = 'wefoiw'
+    path = 'awoeifjawei'
+
+
 class PartiallyFakeBookView(BookView):
-    def __init__(self, *args):
-        super().__init__(*args)
+    @patch('retype.ui.book_view.BookDisplay')
+    @patch('retype.ui.book_view.QTextCursor')
+    @patch('retype.ui.book_view.keymapUpdate')
+    @patch('retype.ui.book_view.Keymap')
+    def __init__(self, win, ctrlr, *_):
+        self.modeline = MagicMock()
+        super().__init__(win, ctrlr)
         self._reset()
+        self.book = FakeBook()
+        self.tobetypedlist = ['abcdef']*5
+        self.chapter_pos = 0
+
+    def _initUI(self):
+        pass
+
+    def setCursor(self):
+        pass
+
+    def updateToolbarActions(self):
+        pass
 
     def _reset(self):
         self._called = None
@@ -19,6 +43,7 @@ class PartiallyFakeBookView(BookView):
 
     def setChapter(self, pos, move_cursor=False, reset=True):
         self._called = ('setChapter', pos, move_cursor, reset)
+        super().setChapter(pos, move_cursor, reset)
 
 
 class FakeWin(QObject):
@@ -62,3 +87,16 @@ class TestBookView:
 
         book_view.setChapterAction('34092834', 'm')
         assert book_view.called == ('setChapter', 34092834, True, True)
+
+    def test_setChapterNegativeValues(self):
+        book_view = _setup()
+
+        # Negative
+        book_view.setChapter(-1, move_cursor=True)
+        assert book_view.chapter_pos == len(book_view.book.chapters) - 1
+
+        # Large negative
+        book_view.setChapter(
+            0 - len(book_view.book.chapters) - 23094823, move_cursor=True)
+        # Should not have changed bc it's out of range
+        assert book_view.chapter_pos == len(book_view.book.chapters) - 1


### PR DESCRIPTION
Also negative indices in range, like -1, should be changing the chapter pos to len(chapters)-1 instead of -1.

It was hard to do the tests without it crashing a certain percentage of the time on Qt cleanup. Qt doesn't like me initialising BookView in the test runner.