### PR TITLE
fix(Console): Traversing command history moves cursor to start

### DIFF
--- a/retype/console/command_service.py
+++ b/retype/console/command_service.py
@@ -146,6 +146,10 @@ class CommandService(object):
 
             self.command_history_pos = None
 
+    def setText(self, text):
+        # type: (CommandService, str) -> None
+        self._console.setText(text)
+
     def commandHistoryUp(self):
         # type: (CommandService) -> None
         if not self.command_history:
@@ -157,7 +161,7 @@ class CommandService(object):
             if len(self.command_history) <= abs(self.command_history_pos):
                 return
             self.command_history_pos -= 1
-        self._console.setText(self.command_history[self.command_history_pos])
+        self.setText(self.command_history[self.command_history_pos])
         logger.debug("command_history_pos: %s, command_history: %s" %
                      (self.command_history_pos, self.command_history))
 
@@ -166,12 +170,12 @@ class CommandService(object):
         if not self.command_history_pos:
             return
         if self.command_history_pos == -1:
-            self._console.setText(self._current_input)
+            self.setText(self._current_input)
             self.command_history_pos = None
             return
         else:
             self.command_history_pos += 1
-        self._console.setText(self.command_history[self.command_history_pos])
+        self.setText(self.command_history[self.command_history_pos])
         logger.debug("command_history_pos: %s, command_history: %s" %
                      (self.command_history_pos, self.command_history))
 

--- a/retype/console/console.py
+++ b/retype/console/console.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from qt import pyqtSignal, Qt, QSizePolicy
+from qt import pyqtSignal, Qt, QSizePolicy, QTextCursor
 
 from typing import TYPE_CHECKING
 
@@ -94,7 +94,12 @@ class Console(LineEdit):
 
     def clear(self):
         # type: (Console) -> None
-        self.setText('')
+        super().setText('')
+
+    def setText(self, text):
+        # type: (Console, str) -> None
+        super().setText(text)
+        self.moveCursor(QTextCursor.MoveOperation.EndOfLine)
 
     def keyPressEvent(self, e):
         # type: (Console, QKeyEvent) -> None

--- a/retype/ui/book_view.py
+++ b/retype/ui/book_view.py
@@ -613,7 +613,6 @@ class BookView(QWidget):
             except ValueError:
                 return
             h.fillChars(n)
-            self._console.moveCursor(QTextCursor.MoveOperation.EndOfLine)
 
     def calcLinePos(self, cursor_pos):
         # type: (BookView, int) -> int


### PR DESCRIPTION
setText by default moves the cursor to the start. We need to explicitly move it to the end after each setText. To facilitate this, I override setText on Console to move the cursor to the end after.

Now BookView's fillCharsAction doesn't need to concern itself with this either.