### PR TITLE
fix(Customisation): Line splits crash on recreating same editor

### DIFF
--- a/retype/ui/customisation_dialog.py
+++ b/retype/ui/customisation_dialog.py
@@ -973,7 +973,7 @@ class SDictEntryEditor(QWidget):
 
     def keep(self):
         # type: (SDictEntryEditor) -> SDictEntry
-        return {'keep': self.keep_e.isChecked()}
+        return self.keep_e.isChecked()
 
     def themeUpdate(self):
         # type: (SDictEntryEditor) -> None


### PR DESCRIPTION
Data was getting nested like {'keep': {'keep': False}}
instead of {'keep': False}