### PR TITLE
fix(Keymap): Default bindings with argstrs don't work on 1st launch

### DIFF
--- a/retype/ui/customisation_dialog.py
+++ b/retype/ui/customisation_dialog.py
@@ -2281,6 +2281,10 @@ class KeymapWidget(QWidget):
             logger.debug(f'Current keymap {file_path} not found. This is\
  normal on first launch or if it has not been saved yet. Falling back to\
  default values.')
+            # In that case force keymapUpdate, because widgets may
+            # have default bindings with argstrs that need actions
+            # created.
+            Keymap.notifier.changed.emit()
         # Filter out selectors that don't exist
         values = values or self.default_values
         return {s: values[s] for s in self.default_values.keys()}


### PR DESCRIPTION
On first launch there is no current keymap file yet and Keymap.set_ doesn't get called, but even if we were to call it, the notifier wouldn't get triggered since the bindings don't change, so keymapUpdate doesn't get called. Bindings with argstrs need QActions to be created and added to the widget which happens in keymapUpdate, so we need to trigger it if there isn't a current keymap file too.