### PR TITLE
fix(Keymap): Prevent Qt "checked" boolean argument passing to slots

### DIFF
--- a/retype/controllers/menu_controller.py
+++ b/retype/controllers/menu_controller.py
@@ -38,7 +38,8 @@ class MenuController(QObject):
         self.actions = {
             'Menu.quit': {
                 'widget': fileMenu, 'name': '&Quit',
-                'func': self.controller.quit, 'icon': 'door',
+                'func': lambda: self.controller.quit(),
+                'icon': 'door',
             },
             'Menu.setViewByEnum:1': {
                 'widget': viewMenu, 'name': '&Shelf View',
@@ -60,20 +61,23 @@ class MenuController(QObject):
             },
             'Menu.showTypespeed': {
                 'widget': gamesMenu, 'name': '&Typespeed',
-                'func': self.controller.showTypespeed, 'icon': 'typespeed',
+                'func': lambda: self.controller.showTypespeed(),
+                'icon': 'typespeed',
             },
             'Menu.showSteno': {
                 'widget': gamesMenu, 'name': '&Learn Stenography',
-                'func': self.controller.showSteno, 'icon': 'steno',
+                'func': lambda: self.controller.showSteno(),
+                'icon': 'steno',
             },
             'Menu.showCustomisationDialog': {
                 'widget': optionsMenu, 'name': '&Customise retype',
-                'func': self.controller.showCustomisationDialog,
+                'func': lambda: self.controller.showCustomisationDialog(),
                 'icon': 'customise',
             },
             'Menu.about': {
                 'widget': helpMenu, 'name': "&About",
-                'func': self.controller.showAboutDialog, 'icon': 'about',
+                'func': lambda: self.controller.showAboutDialog(),
+                'icon': 'about',
             },
             'Menu.documentation': {
                 'widget': helpMenu,
@@ -90,7 +94,7 @@ class MenuController(QObject):
             },
             'Main.load': {
                 'widget': self._menu,
-                'func': self.controller.loadBook,
+                'func': lambda: self.controller.loadBook(),
                 'args_regex': r'\d+',
                 'args_func': lambda s: self.controller.loadBook(int(s)),
             },

--- a/retype/services/keymap.py
+++ b/retype/services/keymap.py
@@ -119,6 +119,14 @@ def populateKeymaps(app_path, user_path):
             break  # do not recurse
 
 
+def logReminderIfNonLambda(func):
+    # type: (Callable | None) -> None
+    if func and func.__name__ != "<lambda>":
+        logger.warning(f'{func.__name__} is not a lambda; remember that \
+Qt sends a boolean as first argument, which could cause bugs if this \
+function expects a different argument.')
+
+
 def genActions(actions, widget=None):
     # type: (ActionsInfo, QWidget | None) -> None
     """Utility function to generate QActions from a ActionInfo dict"""
@@ -134,7 +142,9 @@ def genActions(actions, widget=None):
             widget = info.pop('widget', None) or widget
             widget_ui = info.pop('widget_ui', None)
             func = info.pop('func', None)
+            logReminderIfNonLambda(func)
             func_ui = info.pop('func_ui', None)
+            logReminderIfNonLambda(func_ui)
             if widget_ui and func_ui:
                 action_ui = makeAction(**info, widget=widget_ui, func=func_ui)
                 info['action_ui'] = action_ui

--- a/retype/ui/book_view.py
+++ b/retype/ui/book_view.py
@@ -268,14 +268,14 @@ class BookView(QWidget):
             'BookView.switchToShelves':
             {
                 'name': 'Back to shelves',
-                'func': self.switchToShelves,
+                'func': lambda: self.switchToShelves(),
                 'widget': self.toolbar,
             },
             'BookView.gotoCursorPosition':
             {
                 'name': 'Cursor position',
-                'func': self.gotoCursorPosition,
-                'func_ui': self.gotoCursorPositionAction,
+                'func': lambda: self.gotoCursorPosition(),
+                'func_ui': lambda: self.gotoCursorPositionAction(),
                 'tooltip': 'Go to the cursor position. Hold Ctrl to move\
  cursor to your current position',
                 'icon': 'cursor',
@@ -287,8 +287,8 @@ class BookView(QWidget):
             'BookView.previousChapter':
             {
                 'name': 'Previous chapter',
-                'func': self.previousChapter,
-                'func_ui': self.previousChapterAction,
+                'func': lambda: self.previousChapter(),
+                'func_ui': lambda: self.previousChapterAction(),
                 'tooltip': 'Go to the previous chapter. Hold Ctrl to move\
  cursor with you as well',
                 'icon': 'arrow-left',
@@ -300,8 +300,8 @@ class BookView(QWidget):
             'BookView.nextChapter':
             {
                 'name': 'Next chapter',
-                'func': self.nextChapter,
-                'func_ui': self.nextChapterAction,
+                'func': lambda: self.nextChapter(),
+                'func_ui': lambda: self.nextChapterAction(),
                 'tooltip': 'Go to the next chapter. Hold Ctrl to move cursor\
  with you as well',
                 'icon': 'arrow-right',
@@ -312,7 +312,7 @@ class BookView(QWidget):
             },
             'BookView.setChapter':
             {
-                'func': self.setChapterAction,
+                'func': lambda: self.setChapterAction(),
                 'args_regex': r'(-?\d+|next|n|previous|prev|p)( (m|move))?',
                 'args_func': lambda s: self.setChapterAction(*s.split()),
                 'widget': self,
@@ -320,7 +320,7 @@ class BookView(QWidget):
             'BookView.skipLine':
             {
                 'name': 'Skip line',
-                'func': self.advanceLine,
+                'func': lambda: self.advanceLine(),
                 'tooltip': 'Move cursor to next line',
                 'icon': 'skip',
                 'widget': self.toolbar,
@@ -335,14 +335,14 @@ class BookView(QWidget):
             'BookView.zoomIn':
             {
                 'name': 'Increase font size',
-                'func': self.display.zoomIn,
+                'func': lambda: self.display.zoomIn(),
                 'icon': 't-up',
                 'widget': self.toolbar,
             },
             'BookView.zoomOut':
             {
                 'name': 'Decrease font size',
-                'func': self.display.zoomOut,
+                'func': lambda: self.display.zoomOut(),
                 'icon': 't-down',
                 'widget': self.toolbar,
             }


### PR DESCRIPTION
It had broken zoom in and out and it's not the first time I'm bitten by this. Added a warning if an action function isn't a lambda so that the only arguments passed will be those passed in explicitly.