### PR TITLE
fix(gotoCursorPosition): Clear console first regardless of move

### DIFF
--- a/retype/ui/book_view.py
+++ b/retype/ui/book_view.py
@@ -698,8 +698,8 @@ class BookView(QWidget):
         # type: (BookView, bool) -> None
         if self.chapter_pos is None:
             return
+        self._controller.console.clear()
         if move:
-            self._controller.console.clear()
             self.setChapter(self.viewed_chapter_pos, True)
             self.updateProgress()
         else:


### PR DESCRIPTION
We should actually clear it always for this command, unlike setChapter where we only clear if `move` (so I can see why I made this mistake).