### PR TITLE
fix: Handle OSError when opening files

### DIFF
--- a/retype/constants.py
+++ b/retype/constants.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import logging
 from sys import version as PYTHON_VERSION_STR
 from sys import platform
 from ebooklib import VERSION as EBOOKLIB_VERSION
@@ -10,6 +11,7 @@ from typing import TYPE_CHECKING
 from retype.resource_handler import root_path, getLibraryPath, getIncludePath
 from retype import __version__
 
+logger = logging.getLogger(__name__)
 
 iswindows = platform.lower() in ['win32', 'win64']
 ismacos = 'darwin' in platform.lower()
@@ -128,8 +130,12 @@ def getBuilddate():
         return builddate
     path = os.path.join(getIncludePath(), 'builddate.txt')
     if os.path.exists(path):
-        with open(path, 'r') as f:
-            builddate = f.read()
+        try:
+            with open(path, 'r') as f:
+                builddate = f.read()
+        except OSError as e:
+            logger.error(f"Failed to get builddate from {path}\n{e}",
+                         exc_info=True)
     return builddate
 
 

--- a/retype/controllers/library.py
+++ b/retype/controllers/library.py
@@ -35,6 +35,21 @@ class LibraryController(object):
         self._user_dir = value
         self.save_abs_path = os.path.join(value, 'save.json')
 
+    def checksum(self, path):
+        # type: (LibraryController, str) -> str | None
+        checksum = None
+        try:
+            checksum = generate_file_md5(path)
+        except OSError as e:
+            s = (f'Unable to read epub {self.idn}:\n{self.path}.\n\n'
+                 'This is not fatal, but the book will not be loaded.')
+            logger.error(f"{s}\n{e}", exc_info=True)
+            msg = QMessageBox(QMessageBox.Icon.Warning, 'retype', s)
+            msg.setDetailedText(f'Path: {path}\n\n'
+                                f'{traceback.format_exc()}')
+            msg.exec()
+        return checksum
+
     def indexLibrary(self, library_paths):
         # type: (LibraryController, list[str]) -> dict[int, LibraryItem]
         book_checksum_list = []
@@ -45,8 +60,8 @@ class LibraryController(object):
                 for f in files:
                     if f.lower().endswith(".epub"):
                         path = os.path.join(root, f)
-                        checksum = generate_file_md5(path)
-                        if checksum in book_checksum_list:
+                        checksum = self.checksum(path)
+                        if not checksum or checksum in book_checksum_list:
                             continue
                         book_checksum_list.append(checksum)
                         library_items[idn] = LibraryItem(idn, path, checksum)
@@ -125,7 +140,9 @@ class LibraryController(object):
                     #  replacing it with a checksum, or moving the file back.
                     checksum = key
                 else:
-                    checksum = generate_file_md5(key)
+                    checksum = self.checksum(key)
+                    if not checksum:  # Other OSError happened
+                        checksum = key
                     self.addFriendlyName(save[key], key)
             else:  # assume it’s a checksum
                 checksum = key

--- a/retype/controllers/library.py
+++ b/retype/controllers/library.py
@@ -80,12 +80,8 @@ class LibraryController(object):
         book_view.display.centreAroundCursor()
 
     def save(self, book, data):
-        # type: (LibraryController, BookWrapper, SaveData) -> None
+        # type: (LibraryController, BookWrapper, SaveData) -> bool
         book.save_data = data
-
-        if not os.path.exists(self._user_dir):
-            logger.error(f'Unable to find user_dir {self._user_dir}')
-            return
 
         self.addFriendlyName(data, book.path)
         key = book.checksum
@@ -95,8 +91,20 @@ class LibraryController(object):
         else:
             save = self.save_file_contents = {key: data}
 
-        with open(self.save_abs_path, 'w', encoding='utf-8') as f:
-            json.dump(save, f, indent=2)
+        try:
+            with open(self.save_abs_path, 'w', encoding='utf-8') as f:
+                json.dump(save, f, indent=2)
+        except OSError as e:
+            s = 'Unable to save progress to disk.'
+            if e is FileNotFoundError:
+                s += f' Unable to find user_dir {self._user_dir}.'
+            logger.error(f"{s}\n{e}", exc_info=True)
+            msg = QMessageBox(QMessageBox.Icon.Warning, 'retype', s)
+            msg.setDetailedText(f'Path: {self.save_abs_path}\n\n'
+                                f'{traceback.format_exc()}')
+            msg.exec()
+            return False
+        return True
 
     def migrateV1Save(self, save):
         # type: (LibraryController, Save) -> Save
@@ -138,8 +146,16 @@ class LibraryController(object):
         # type: (LibraryController) -> Save
         if os.path.exists(self.save_abs_path):
             logger.info(f'Read save: {self.save_abs_path}')
-            with open(self.save_abs_path, 'r') as f:
-                save = json.load(f)  # type: Save
+            try:
+                with open(self.save_abs_path, 'r') as f:
+                    save = json.load(f)  # type: Save
+            except OSError as e:
+                s = 'Unable to read save file.'
+                logger.error(f"{s}\n{e}", exc_info=True)
+                msg = QMessageBox(QMessageBox.Icon.Warning, 'retype', s)
+                msg.setDetailedText(f'Path: {self.save_abs_path}\n\n'
+                                    f'{traceback.format_exc()}')
+                msg.exec()
         else:
             logger.debug(
                 f'Save path {self.save_abs_path} not found.\n'

--- a/retype/controllers/safe_config.py
+++ b/retype/controllers/safe_config.py
@@ -1,7 +1,9 @@
 import os
 import json
 import logging
+import traceback
 from copy import deepcopy
+from qt import QMessageBox
 
 from typing import TYPE_CHECKING
 
@@ -31,7 +33,11 @@ class _SafeConfig:
     def load(self, path):
         # type: (_SafeConfig, str) -> Config
         config = self._load(path)
-        user_dir = config['user_dir'] if config else None
+        if config is None:      # Loading failed
+            # Nothing modifies it, but may as well explicitly avoid mutation
+            return deepcopy(default_config)
+
+        user_dir = config['user_dir']
         if user_dir and not self.isPathDefaultUserDir(user_dir):
             custom_path = os.path.join(user_dir, self.config_rel_path)
             logger.debug("Non-default user_dir: {}\n\
@@ -40,16 +46,23 @@ Attempting to load config from: {}".format(user_dir, custom_path))
             if not config:
                 config = deepcopy(default_config)
                 config['user_dir'] = user_dir
-                return config
-        return config or default_config
+        return config
 
     def _load(self, path):
         # type: (_SafeConfig, str) -> Config | None
         if os.path.exists(path):
             logger.info(f'Read config: {path}')
-            with open(path, 'r') as f:
-                config = json.load(f)  # type: Config
-                return config
+            try:
+                with open(path, 'r') as f:
+                    config = json.load(f)  # type: Config
+                    return config
+            except OSError as e:
+                s = 'Unable to read config file.'
+                logger.error(f"{s}\n{e}", exc_info=True)
+                msg = QMessageBox(QMessageBox.Icon.Warning, 'retype', s)
+                msg.setDetailedText(f'Path: {path}\n\n'
+                                    f'{traceback.format_exc()}')
+                msg.exec()
         else:
             logger.debug(
                 f'Config path {path} not found.\n'
@@ -64,23 +77,47 @@ Attempting to load config from: {}".format(user_dir, custom_path))
     def save(self):
         # type: (_SafeConfig) -> None
         user_dir = self.raw['user_dir']
-        if not os.path.exists(user_dir):
-            logger.error(f'Unable to find user_dir {user_dir}')
+        path = os.path.join(user_dir, self.config_rel_path)
+        if not self._save(path, self.raw):  # Saving failed
             return
 
-        path = os.path.join(user_dir, self.config_rel_path)
-        with open(path, 'w') as f:
-            json.dump(self.raw, f, indent=2)
         if not self.isPathDefaultUserDir(user_dir):
-            path = os.path.join(self.default_user_dir, self.config_rel_path)
-            if os.path.exists(path):
-                with open(path, 'r') as f:
-                    dconfig = json.load(f)  # type: Config
-                    dconfig['user_dir'] = user_dir
-                with open(path, 'w') as f:
-                    json.dump(dconfig, f, indent=2)
-            else:
-                logger.error(f'Unable to find dconfig {path}')
+            dconfig = self.loadDconfig()
+            if dconfig is not None:
+                dconfig['user_dir'] = user_dir
+                self._save(path, dconfig)
+
+    def _save(self, path, data):
+        # type: (_SafeConfig, str, Config) -> bool
+        try:
+            with open(path, 'w') as f:
+                logger.debug(f'Saving config: {path}')
+                json.dump(data, f, indent=2)
+        except OSError as e:
+            s = 'Unable to save config file.'
+            logger.error(f"{s}\n{e}", exc_info=True)
+            msg = QMessageBox(QMessageBox.Icon.Warning, 'retype', s)
+            msg.setDetailedText(f'Path: {path}\n\n'
+                                f'{traceback.format_exc()}')
+            msg.exec()
+            return False
+        return True
+
+    def loadDconfig(self):
+        # type: (_SafeConfig) -> Config | None
+        dconfig = None
+        path = os.path.join(self.default_user_dir, self.config_rel_path)
+        try:
+            with open(path, 'r') as f:
+                dconfig = json.load(f)  # type: Config
+        except OSError as e:
+            s = 'Unable to load dconfig file.'
+            logger.error(f"{s}\n{e}", exc_info=True)
+            msg = QMessageBox(QMessageBox.Icon.Warning, 'retype', s)
+            msg.setDetailedText(f'Path: {path}\n\n'
+                                f'{traceback.format_exc()}')
+            msg.exec()
+        return dconfig
 
     def __getitem__(self, key, default=None):
         # type: (_SafeConfig, str, object | None) -> object

--- a/retype/ui/book_view.py
+++ b/retype/ui/book_view.py
@@ -689,7 +689,7 @@ class BookView(QWidget):
                 self.book.dirty = False
             else:               # Saving failed
                 logger.info("Can't save. Deactivating autosave.")
-                self.autosave.save.disconnect(self.maybeSave)
+                self.autosave.on = False
 
     def switchToShelves(self):
         # type: (BookView) -> None

--- a/retype/ui/book_view.py
+++ b/retype/ui/book_view.py
@@ -685,8 +685,11 @@ class BookView(QWidget):
             data = {'persistent_pos': self.persistent_pos,
                     'chapter_pos': self.chapter_pos,
                     'progress': self.progress}  # type: SaveData
-            self._library.save(self.book, data)  # type: ignore[arg-type]
-            self.book.dirty = False
+            if self._library.save(self.book, data):  # type: ignore[arg-type]
+                self.book.dirty = False
+            else:               # Saving failed
+                logger.info("Can't save. Deactivating autosave.")
+                self.autosave.save.disconnect(self.maybeSave)
 
     def switchToShelves(self):
         # type: (BookView) -> None

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -28,15 +28,13 @@ def _setup():
     return library, book, data, save
 
 
-@patch('os.path.exists')
 @patch('builtins.open')
 @patch('json.dump')
 class TestLibraryControllerSaveFunction:
     def test_save_file_exists_and_has_book_save_data_already(
-            self, m_jsondump, m_open, m_exists):
+            self, m_jsondump, m_open):
         (library, book, data, save) = _setup()
 
-        m_exists.return_value = True
         library.save_file_contents = {book.checksum: 'other-data'}
 
         library.save(book, data)
@@ -46,10 +44,8 @@ class TestLibraryControllerSaveFunction:
         assert book.save_data == data
 
     def test_save_file_exists_and_does_not_have_book_save_data_yet(
-            self, m_jsondump, m_open, m_exists):
+            self, m_jsondump, m_open):
         (library, book, data, _) = _setup()
-
-        m_exists.return_value = True
 
         library.save(book, data)
 
@@ -58,11 +54,10 @@ class TestLibraryControllerSaveFunction:
         assert book.save_data == data
 
     def test_save_file_two_books_in_save(
-            self, m_jsondump, m_open, m_exists):
+            self, m_jsondump, m_open):
         (library, book, data, _) = _setup()
         save = {'other': data, book.checksum: data}
 
-        m_exists.return_value = True
         library.save_file_contents = save
 
         library.save(book, data)
@@ -70,27 +65,14 @@ class TestLibraryControllerSaveFunction:
         m_jsondump.assert_called_once_with(save, ANY, indent=2)
         assert book.save_data == data
 
-    def test_save_file_does_not_exist_and_user_dir_does(
-            self, m_jsondump, m_open, m_exists):
+    def test_save_file_does_not_exist(
+            self, m_jsondump, m_open):
         (library, book, data, save) = _setup()
-
-        m_exists.side_effect = [True, False]
 
         library.save(book, data)
 
         m_jsondump.assert_called_once_with(
             {book.checksum: data}, ANY, indent=2)
-        assert book.save_data == data
-
-    def test_user_dir_does_not_exist(
-            self, m_jsondump, m_open, m_exists):
-        (library, book, data, save) = _setup()
-
-        m_exists.return_value = False
-
-        library.save(book, data)
-
-        m_jsondump.assert_not_called()
         assert book.save_data == data
 
 


### PR DESCRIPTION
There was especially a problem with autosave on a read-only volume causing a crash. Now in that situation there is an error dialog box with information and autosave gets disabled. I went through all the other uses of `open(` to make sure OSError is handled.