### PR TITLE
ci: Add a reminder to bump version file

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
       version:
         type: string
         required: true
-        description: SemVer/name of release
+        description: SemVer/name of release (REMEMBER TO BUMP VERSION FILE)
       release:
         type: boolean
         required: false


### PR DESCRIPTION
I thought about removing the version input altogether and extracting it from the file to force me to update it there, but it's useful to have the input for test builds. So I just added a dumb reminder to the field name, maybe that will help (especially if I take a long break and come back and forget the version file is a thing)